### PR TITLE
Added a `--regex` option to `twiggy paths`. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,7 @@ version = "0.1.0"
 dependencies = [
  "csv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "twiggy-ir 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,7 @@ dependencies = [
  "csv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "twiggy-ir 0.1.0",
 ]
 

--- a/analyze/Cargo.toml
+++ b/analyze/Cargo.toml
@@ -16,6 +16,7 @@ twiggy-ir = { version = "0.1.0", path = "../ir" }
 twiggy-opt = { version = "0.1.0", path = "../opt", default-features = false }
 twiggy-traits = { version = "0.1.0", path = "../traits" }
 csv = "1.0.0"
+regex = "1.0.0"
 serde = "1.0.58"
 serde_derive = "1.0.58"
 petgraph = "0.4.12"

--- a/analyze/analyze.rs
+++ b/analyze/analyze.rs
@@ -5,12 +5,12 @@
 
 #[macro_use]
 extern crate serde_derive;
+extern crate csv;
 extern crate petgraph;
 extern crate regex;
 extern crate twiggy_ir as ir;
 extern crate twiggy_opt as opt;
 extern crate twiggy_traits as traits;
-extern crate csv;
 
 mod json;
 
@@ -409,7 +409,6 @@ impl traits::Emit for DominatorTree {
             id: ir::Id,
             wtr: &mut csv::Writer<&mut io::Write>,
         ) -> Result<(), traits::Error> {
-
             #[derive(Serialize, Debug)]
             #[serde(rename_all = "PascalCase")]
             struct CsvRecord {

--- a/ir/ir.rs
+++ b/ir/ir.rs
@@ -163,7 +163,8 @@ impl Items {
     /// Iterate over an item's neighbors.
     pub fn neighbors(&self, id: Id) -> Neighbors {
         Neighbors {
-            inner: self.edges
+            inner: self
+                .edges
                 .get(&id)
                 .map_or_else(|| [].iter(), |edges| edges.iter()),
         }
@@ -172,7 +173,8 @@ impl Items {
     /// Iterate over an item's predecessors.
     pub fn predecessors(&self, id: Id) -> Predecessors {
         Predecessors {
-            inner: self.predecessors
+            inner: self
+                .predecessors
                 .as_ref()
                 .expect("To access predecessors, must have already called compute_predecessors")
                 .get(&id)

--- a/opt/definitions.rs
+++ b/opt/definitions.rs
@@ -224,6 +224,10 @@ pub struct Paths {
     /// This direction of the path traversal.
     #[structopt(long = "descending")]
     descending: bool,
+
+    /// Whether or not `functions` should be treated as regular expressions.
+    #[structopt(long = "regex")]
+    using_regexps: bool,
 }
 
 impl Default for Paths {
@@ -240,6 +244,7 @@ impl Default for Paths {
             max_depth: 10,
             max_paths: 10,
             descending: false,
+            using_regexps: false,
         }
     }
 }
@@ -281,6 +286,11 @@ impl Paths {
         self.descending
     }
 
+    /// Whether or not `functions` should be treated as regular expressions.
+    pub fn using_regexps(&self) -> bool {
+        self.using_regexps
+    }
+
     /// Set the maximum depth to print the paths.
     pub fn set_max_depth(&mut self, max_depth: u32) {
         self.max_depth = max_depth;
@@ -296,6 +306,10 @@ impl Paths {
         self.descending = descending;
     }
 
+    /// Set Whether or not `functions` should be treated as regular expressions.
+    pub fn set_using_regexps(&mut self, using_regexps: bool) {
+        self.using_regexps = using_regexps;
+    }
 }
 
 /// List the generic function monomorphizations that are contributing to

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -16,3 +16,4 @@ failure = "0.1.1"
 parity-wasm = "0.28.0"
 twiggy-ir = { version = "0.1.0", path = "../ir" }
 csv = "1.0.0-beta.5"
+regex = "1.0.0"

--- a/traits/traits.rs
+++ b/traits/traits.rs
@@ -122,7 +122,6 @@ pub enum OutputFormat {
 
     // /// Graphviz dot format.
     // Dot,
-
     /// Comma-separated values (CSV) format.
     Csv,
     /// JavaScript Object Notation format.

--- a/traits/traits.rs
+++ b/traits/traits.rs
@@ -6,6 +6,7 @@
 extern crate csv;
 #[macro_use]
 extern crate failure;
+extern crate regex;
 
 extern crate parity_wasm as wasm;
 extern crate twiggy_ir as ir;
@@ -53,6 +54,9 @@ enum ErrorInner {
 
     #[fail(display = "CSV error: {}", _0)]
     Csv(#[cause] csv::Error),
+
+    #[fail(display = "Regex error: {}", _0)]
+    Regex(#[cause] regex::Error),
 }
 
 impl From<io::Error> for Error {
@@ -83,6 +87,14 @@ impl From<csv::Error> for Error {
     fn from(e: csv::Error) -> Error {
         Error {
             inner: Box::new(ErrorInner::Csv(e)),
+        }
+    }
+}
+
+impl From<regex::Error> for Error {
+    fn from(e: regex::Error) -> Error {
+        Error {
+            inner: Box::new(ErrorInner::Regex(e)),
         }
     }
 }

--- a/twiggy/tests/expectations/paths_test_regex_called_any
+++ b/twiggy/tests/expectations/paths_test_regex_called_any
@@ -1,0 +1,18 @@
+ Shallow Bytes │ Shallow % │ Retaining Paths
+───────────────┼───────────┼────────────────────────────────────────
+             5 ┊     3.47% ┊ calledOnce
+               ┊           ┊   ⬑ func[0]
+               ┊           ┊       ⬑ woof
+               ┊           ┊           ⬑ func[3]
+               ┊           ┊               ⬑ export "woof"
+             5 ┊     3.47% ┊ calledTwice
+               ┊           ┊   ⬑ func[1]
+               ┊           ┊       ⬑ bark
+               ┊           ┊           ⬑ func[2]
+               ┊           ┊               ⬑ export "bark"
+               ┊           ┊               ⬑ awoo
+               ┊           ┊                   ⬑ func[4]
+               ┊           ┊                       ⬑ export "awoo"
+               ┊           ┊       ⬑ woof
+               ┊           ┊           ⬑ func[3]
+               ┊           ┊               ⬑ export "woof"

--- a/twiggy/tests/expectations/paths_test_regex_exports
+++ b/twiggy/tests/expectations/paths_test_regex_exports
@@ -1,0 +1,5 @@
+ Shallow Bytes │ Shallow % │ Retaining Paths
+───────────────┼───────────┼────────────────
+             7 ┊     4.86% ┊ export "awoo"
+             7 ┊     4.86% ┊ export "bark"
+             7 ┊     4.86% ┊ export "woof"

--- a/twiggy/tests/expectations/paths_test_regex_exports_desc
+++ b/twiggy/tests/expectations/paths_test_regex_exports_desc
@@ -1,0 +1,29 @@
+ Shallow Bytes │ Shallow % │ Retaining Paths
+───────────────┼───────────┼──────────────────────────────────────
+             7 ┊     4.86% ┊ export "awoo"
+               ┊           ┊   ↳ func[4]
+               ┊           ┊       ↳ type[0]
+               ┊           ┊       ↳ awoo
+               ┊           ┊           ↳ func[2]
+               ┊           ┊               ↳ type[0]
+               ┊           ┊               ↳ bark
+               ┊           ┊                   ↳ func[1]
+               ┊           ┊                       ↳ type[0]
+               ┊           ┊                       ↳ calledTwice
+             7 ┊     4.86% ┊ export "bark"
+               ┊           ┊   ↳ func[2]
+               ┊           ┊       ↳ type[0]
+               ┊           ┊       ↳ bark
+               ┊           ┊           ↳ func[1]
+               ┊           ┊               ↳ type[0]
+               ┊           ┊               ↳ calledTwice
+             7 ┊     4.86% ┊ export "woof"
+               ┊           ┊   ↳ func[3]
+               ┊           ┊       ↳ type[0]
+               ┊           ┊       ↳ woof
+               ┊           ┊           ↳ func[0]
+               ┊           ┊               ↳ type[0]
+               ┊           ┊               ↳ calledOnce
+               ┊           ┊           ↳ func[1]
+               ┊           ┊               ↳ type[0]
+               ┊           ┊               ↳ calledTwice

--- a/twiggy/tests/tests.rs
+++ b/twiggy/tests/tests.rs
@@ -234,7 +234,7 @@ test!(
     paths_test_regex_called_any,
     "paths",
     "./fixtures/paths_test.wasm",
-    "called*",
+    "called.*",
     "--regex"
 );
 
@@ -242,7 +242,7 @@ test!(
     paths_test_regex_exports,
     "paths",
     "./fixtures/paths_test.wasm",
-    "export \"*\"",
+    "export \".*\"",
     "--regex"
 );
 
@@ -250,7 +250,7 @@ test!(
     paths_test_regex_exports_desc,
     "paths",
     "./fixtures/paths_test.wasm",
-    "export \"*\"",
+    "export \".*\"",
     "--descending",
     "--regex"
 );

--- a/twiggy/tests/tests.rs
+++ b/twiggy/tests/tests.rs
@@ -230,6 +230,31 @@ test!(
     "json"
 );
 
+test!(
+    paths_test_regex_called_any,
+    "paths",
+    "./fixtures/paths_test.wasm",
+    "called*",
+    "--regex"
+);
+
+test!(
+    paths_test_regex_exports,
+    "paths",
+    "./fixtures/paths_test.wasm",
+    "export \"*\"",
+    "--regex"
+);
+
+test!(
+    paths_test_regex_exports_desc,
+    "paths",
+    "./fixtures/paths_test.wasm",
+    "export \"*\"",
+    "--descending",
+    "--regex"
+);
+
 // This should not fail to open and write `whatever-output.txt`.
 test!(
     output_to_file,


### PR DESCRIPTION
Items can now be specified by regex rather than exact name. Solves #58.

This adds a dependency on the `regex` crate to `twiggy_analyze`. I refactored the statement that initializes the `functions` member of the `Paths` struct slightly, it was getting a little large so I think having some closures helps readability slightly.

I added a `--regex` option rather than applying this to all cases because it ended up changing the output in other situations and broke a number of other tests. We could make it the default if you would like, but having it gated behind an option seemed like a low-impact way to get this done.

If this approach makes sense to you, I don't mind taking care of #59 as well, since I'm sure a lot of the work there will be nearly identical to this :)

p.s. Changes to the `ir/ir.rs` file were due to `cargo fmt`, unrelated to the work here.