### PR TITLE
Fix inconsistent indentation in opt/definitions.rs

### DIFF
--- a/opt/definitions.rs
+++ b/opt/definitions.rs
@@ -120,7 +120,7 @@ impl Top {
 pub struct Dominators {
     /// The path to the input binary to size profile.
     #[cfg(feature = "cli")]
-   #[structopt(parse(from_os_str))]
+    #[structopt(parse(from_os_str))]
     input: path::PathBuf,
 
     /// The destination to write the output to. Defaults to `stdout`.


### PR DESCRIPTION
Minor fix, I noticed that one of the `#[structopt]` attributes in `opt/definitions.rs` was inconsistently indented.