### PR TITLE
Fix paths_test.wat

### DIFF
--- a/twiggy/tests/fixtures/paths_test.wat
+++ b/twiggy/tests/fixtures/paths_test.wat
@@ -11,10 +11,10 @@
     ;;                  |
     ;;                  v
     ;;     [woof]     [bark]
-    ;;       |         | |
-    ;;       |  -------- |
-    ;;       |  |        |
-    ;;       v  v        v
+    ;;      |  |          |
+    ;;      |  --------   |
+    ;;      |         |   |
+    ;;      v         v   v
     ;; 'calledOnce' 'calledTwice'
     ;; ------------------------------------------------------------------------
     ;; NOTE: The test cases expect that this module is compiled with debug


### PR DESCRIPTION
Noticed a typo in the ascii art in this test fixture. This patch fixes the comments so that the call tree is properly represented.