### PR TITLE
Removed an empty test from traits.rs.

### DIFF
--- a/traits/traits.rs
+++ b/traits/traits.rs
@@ -228,11 +228,3 @@ pub trait Emit {
     #[cfg(feature = "emit_json")]
     fn emit_json(&self, items: &ir::Items, destination: &mut io::Write) -> Result<(), Error>;
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}


### PR DESCRIPTION
Noticed an effectively empty test at the bottom of `traits.rs`. This PR removes that, since it doesn't seem to be serving any practical purpose at the moment.