### PR TITLE
main(): Fix deprecated causes() w/iter_causes()

### DIFF
--- a/twiggy/twiggy.rs
+++ b/twiggy/twiggy.rs
@@ -19,7 +19,7 @@ fn main() {
     let options = opt::Options::from_args();
     if let Err(e) = run(&options) {
         eprintln!("error: {}", e);
-        for c in e.causes().skip(1) {
+        for c in Fail::iter_causes(&e) {
             eprintln!("  caused by: {}", c);
         }
         process::exit(1);


### PR DESCRIPTION
Fixes https://github.com/rustwasm/twiggy/issues/104

Hi :) Since I'm completely new to Rust, it took me a while to figure this out... But that's the best way to learn! :D 

Nevertheless I'm still a bit confused ;) `causes()` is defined in `Fail`. Just like `iter_causes()`. The first can be directy used as method on the `Error` trait (even though being deprecated), the second can't... o.O Why?

I also don't know if my solution really works, since I wasn't be able to raise a simple error somehow for testing :D How to do that?