### PR TITLE
Add --all(-generics|-monos) flags to monos command

### DIFF
--- a/opt/definitions.rs
+++ b/opt/definitions.rs
@@ -367,9 +367,24 @@ pub struct Monos {
     max_generics: u32,
 
     /// The maximum number of individual monomorphizations to list for each
-    /// generic function.
+    /// listed generic function.
     #[structopt(short = "n", long = "max-monos", default_value = "10")]
     max_monos: u32,
+
+    /// List all generics and all of their individual monomorphizations.
+    /// If combined with -g then monomorphizations are hidden.
+    /// Overrides -m <max_generics> and -n <max_monos>
+    #[structopt(short = "a", long = "all")]
+    all_generics_and_monos: bool,
+
+    /// List all generics. Overrides -m <max_generics>
+    #[structopt(long = "all-generics")]
+    all_generics: bool,
+
+    /// List all individual monomorphizations for each listed generic
+    /// function. Overrides -n <max_monos>
+    #[structopt(long = "all-monos")]
+    all_monos: bool,
 }
 
 impl Default for Monos {
@@ -385,6 +400,10 @@ impl Default for Monos {
             only_generics: false,
             max_generics: 10,
             max_monos: 10,
+
+            all_generics_and_monos: false,
+            all_generics: false,
+            all_monos: false,
         }
     }
 }
@@ -403,13 +422,21 @@ impl Monos {
 
     /// The maximum number of generics to list.
     pub fn max_generics(&self) -> u32 {
-        self.max_generics
+        if self.all_generics_and_monos || self.all_generics {
+            u32::MAX
+        } else {
+            self.max_generics
+        }
     }
 
     /// The maximum number of individual monomorphizations to list for each
     /// generic function.
     pub fn max_monos(&self) -> u32 {
-        self.max_monos
+        if self.all_generics_and_monos || self.all_monos {
+            u32::MAX
+        } else {
+            self.max_monos
+        }
     }
 
     /// Set whether to hide individual monomorphizations and only show the
@@ -421,12 +448,22 @@ impl Monos {
     /// Set the maximum number of generics to list.
     pub fn set_max_generics(&mut self, max: u32) {
         self.max_generics = max;
+        self.all_generics = false;
+        if self.all_generics_and_monos {
+            self.all_generics_and_monos = false;
+            self.all_monos = true;
+        }
     }
 
     /// Set the maximum number of individual monomorphizations to list for each
     /// generic function.
     pub fn set_max_monos(&mut self, max: u32) {
         self.max_monos = max;
+        self.all_monos = false;
+        if self.all_generics_and_monos {
+            self.all_generics_and_monos = false;
+            self.all_generics = true;
+        }
     }
 }
 

--- a/twiggy/tests/expectations/monos_all
+++ b/twiggy/tests/expectations/monos_all
@@ -1,0 +1,240 @@
+ Apprx. Bloat Bytes │ Apprx. Bloat % │ Bytes │ %      │ Monomorphizations
+────────────────────┼────────────────┼───────┼────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+               1977 ┊          3.40% ┊  3003 ┊  5.16% ┊ alloc::slice::merge_sort
+                    ┊                ┊  1026 ┊  1.76% ┊     alloc::slice::merge_sort::hb3d195f9800bdad6
+                    ┊                ┊  1026 ┊  1.76% ┊     alloc::slice::merge_sort::hfcf2318d7dc71d03
+                    ┊                ┊   951 ┊  1.63% ┊     alloc::slice::merge_sort::hcfca67f5c75a52ef
+               1302 ┊          2.24% ┊  3996 ┊  6.87% ┊ <&'a T as core::fmt::Debug>::fmt
+                    ┊                ┊  2694 ┊  4.63% ┊     <&'a T as core::fmt::Debug>::fmt::h1c27955d8de3ff17
+                    ┊                ┊   568 ┊  0.98% ┊     <&'a T as core::fmt::Debug>::fmt::hea6a77c4dcddb7ac
+                    ┊                ┊   433 ┊  0.74% ┊     <&'a T as core::fmt::Debug>::fmt::hfbacf6f5c9f53bb2
+                    ┊                ┊   301 ┊  0.52% ┊     <&'a T as core::fmt::Debug>::fmt::h199e8e1c5752e6f1
+                973 ┊          1.67% ┊  1118 ┊  1.92% ┊ core::result::unwrap_failed
+                    ┊                ┊   145 ┊  0.25% ┊     core::result::unwrap_failed::h137aa4f433aba1a9
+                    ┊                ┊   145 ┊  0.25% ┊     core::result::unwrap_failed::h4cc73eb9bf19ce32
+                    ┊                ┊   145 ┊  0.25% ┊     core::result::unwrap_failed::h9bd27c3a9ad7c001
+                    ┊                ┊   138 ┊  0.24% ┊     core::result::unwrap_failed::h9a7678774db14d67
+                    ┊                ┊   138 ┊  0.24% ┊     core::result::unwrap_failed::ha3e58cfc7f422ab4
+                    ┊                ┊   138 ┊  0.24% ┊     core::result::unwrap_failed::ha7651fcaac40f701
+                    ┊                ┊   138 ┊  0.24% ┊     core::result::unwrap_failed::hcb258ce32bda3d85
+                    ┊                ┊   131 ┊  0.23% ┊     core::result::unwrap_failed::hcfddf900474e698a
+                558 ┊          0.96% ┊   714 ┊  1.23% ┊ <alloc::raw_vec::RawVec<T, A>>::double
+                    ┊                ┊   156 ┊  0.27% ┊     <alloc::raw_vec::RawVec<T, A>>::double::h28f86621ee2a10aa
+                    ┊                ┊   156 ┊  0.27% ┊     <alloc::raw_vec::RawVec<T, A>>::double::h956450b93bdc9e1e
+                    ┊                ┊   156 ┊  0.27% ┊     <alloc::raw_vec::RawVec<T, A>>::double::hcb2fb5861b96a3b0
+                    ┊                ┊   147 ┊  0.25% ┊     <alloc::raw_vec::RawVec<T, A>>::double::ha715b4e5cc3c60ae
+                    ┊                ┊    99 ┊  0.17% ┊     <alloc::raw_vec::RawVec<T, A>>::double::h77ff8547127c5db2
+                512 ┊          0.88% ┊   798 ┊  1.37% ┊ std::thread::local::os::destroy_value
+                    ┊                ┊   286 ┊  0.49% ┊     std::thread::local::os::destroy_value::hca8124786bee4a79
+                    ┊                ┊   281 ┊  0.48% ┊     std::thread::local::os::destroy_value::h094cf4f2a025ba2b
+                    ┊                ┊   231 ┊  0.40% ┊     std::thread::local::os::destroy_value::h453d41f6c315da32
+                234 ┊          0.40% ┊   354 ┊  0.61% ┊ alloc::slice::insert_head
+                    ┊                ┊   120 ┊  0.21% ┊     alloc::slice::insert_head::h2cdb84a455761146
+                    ┊                ┊   120 ┊  0.21% ┊     alloc::slice::insert_head::haf6e08236bab8bde
+                    ┊                ┊   114 ┊  0.20% ┊     alloc::slice::insert_head::hed0e79da03eeec8b
+                196 ┊          0.34% ┊   294 ┊  0.51% ┊ <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_fmt
+                    ┊                ┊    98 ┊  0.17% ┊     <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_fmt::h1b74a5fafe15c8eb
+                    ┊                ┊    98 ┊  0.17% ┊     <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_fmt::h24034d1c07bfae93
+                    ┊                ┊    98 ┊  0.17% ┊     <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_fmt::h5ebed3e159974658
+                195 ┊          0.34% ┊   270 ┊  0.46% ┊ <alloc::vec::Vec<T>>::push
+                    ┊                ┊    75 ┊  0.13% ┊     <alloc::vec::Vec<T>>::push::h98b02eda22d1ca25
+                    ┊                ┊    66 ┊  0.11% ┊     <alloc::vec::Vec<T>>::push::h5729b9e7651ef67b
+                    ┊                ┊    66 ┊  0.11% ┊     <alloc::vec::Vec<T>>::push::hc927b4bedb35b00d
+                    ┊                ┊    63 ┊  0.11% ┊     <alloc::vec::Vec<T>>::push::h9415ef699ccc65d8
+                119 ┊          0.20% ┊   180 ┊  0.31% ┊ <core::ops::range::Range<usize> as core::slice::SliceIndex<[T]>>::index_mut
+                    ┊                ┊    61 ┊  0.10% ┊     <core::ops::range::Range<usize> as core::slice::SliceIndex<[T]>>::index_mut::hba42cce6d0c0099b
+                    ┊                ┊    61 ┊  0.10% ┊     <core::ops::range::Range<usize> as core::slice::SliceIndex<[T]>>::index_mut::hbf8fcfe76c1f6657
+                    ┊                ┊    58 ┊  0.10% ┊     <core::ops::range::Range<usize> as core::slice::SliceIndex<[T]>>::index_mut::h1c053f01b6f95d93
+                 95 ┊          0.16% ┊   190 ┊  0.33% ┊ core::fmt::Write::write_fmt
+                    ┊                ┊    95 ┊  0.16% ┊     core::fmt::Write::write_fmt::ha5ae3249cacba520
+                    ┊                ┊    95 ┊  0.16% ┊     core::fmt::Write::write_fmt::hef4632e1398f5ac8
+                 90 ┊          0.15% ┊   167 ┊  0.29% ┊ core::ptr::drop_in_place
+                    ┊                ┊    77 ┊  0.13% ┊     core::ptr::drop_in_place::h494c395f6e046dd8
+                    ┊                ┊    21 ┊  0.04% ┊     core::ptr::drop_in_place::h42ed7c6a38cb8e07
+                    ┊                ┊    21 ┊  0.04% ┊     core::ptr::drop_in_place::h4ca61ce56a679223
+                    ┊                ┊    21 ┊  0.04% ┊     core::ptr::drop_in_place::ha01a5d42ad694a80.222
+                    ┊                ┊     3 ┊  0.01% ┊     core::ptr::drop_in_place::h17156ca791bccf59.513
+                    ┊                ┊     3 ┊  0.01% ┊     core::ptr::drop_in_place::h1c915609313c62ad
+                    ┊                ┊     3 ┊  0.01% ┊     core::ptr::drop_in_place::h3eafb424d17eed5a
+                    ┊                ┊     3 ┊  0.01% ┊     core::ptr::drop_in_place::h5fe186521e50398c
+                    ┊                ┊     3 ┊  0.01% ┊     core::ptr::drop_in_place::h866e65b55bb41ec8
+                    ┊                ┊     3 ┊  0.01% ┊     core::ptr::drop_in_place::h90b51321c83f0b52
+                    ┊                ┊     3 ┊  0.01% ┊     core::ptr::drop_in_place::hc08d232cbad3f181
+                    ┊                ┊     3 ┊  0.01% ┊     core::ptr::drop_in_place::he20df9406e8bd108
+                    ┊                ┊     3 ┊  0.01% ┊     core::ptr::drop_in_place::hf66b364ab6530cb0.198
+                 51 ┊          0.09% ┊    68 ┊  0.12% ┊ <&'a T as core::fmt::Display>::fmt
+                    ┊                ┊    17 ┊  0.03% ┊     <&'a T as core::fmt::Display>::fmt::h176bc0565ce2f755
+                    ┊                ┊    17 ┊  0.03% ┊     <&'a T as core::fmt::Display>::fmt::h926f24fdf869c3d4
+                    ┊                ┊    17 ┊  0.03% ┊     <&'a T as core::fmt::Display>::fmt::h9a5e4ca609ef3195
+                    ┊                ┊    17 ┊  0.03% ┊     <&'a T as core::fmt::Display>::fmt::hfd15206c852ff237
+                 39 ┊          0.07% ┊    78 ┊  0.13% ┊ core::str::traits::<impl core::slice::SliceIndex<str> for core::ops::range::RangeFrom<usize>>::index::{{closure}}
+                    ┊                ┊    39 ┊  0.07% ┊     core::str::traits::<impl core::slice::SliceIndex<str> for core::ops::range::RangeFrom<usize>>::index::{{closure}}::h551234547249438f
+                    ┊                ┊    39 ┊  0.07% ┊     core::str::traits::<impl core::slice::SliceIndex<str> for core::ops::range::RangeFrom<usize>>::index::{{closure}}::h551234547249438f.1519
+                 30 ┊          0.05% ┊    45 ┊  0.08% ┊ <alloc::raw_vec::RawVec<T, A> as core::ops::drop::Drop>::drop
+                    ┊                ┊    15 ┊  0.03% ┊     <alloc::raw_vec::RawVec<T, A> as core::ops::drop::Drop>::drop::h420ff33e8bc0de30
+                    ┊                ┊    15 ┊  0.03% ┊     <alloc::raw_vec::RawVec<T, A> as core::ops::drop::Drop>::drop::hab66cea5bda1ed02
+                    ┊                ┊    15 ┊  0.03% ┊     <alloc::raw_vec::RawVec<T, A> as core::ops::drop::Drop>::drop::hbe243f4c44295f3d
+                 20 ┊          0.03% ┊    40 ┊  0.07% ┊ core::str::traits::<impl core::slice::SliceIndex<str> for core::ops::range::RangeTo<usize>>::index::{{closure}}
+                    ┊                ┊    20 ┊  0.03% ┊     core::str::traits::<impl core::slice::SliceIndex<str> for core::ops::range::RangeTo<usize>>::index::{{closure}}::hd9bd1f9708957db3
+                    ┊                ┊    20 ┊  0.03% ┊     core::str::traits::<impl core::slice::SliceIndex<str> for core::ops::range::RangeTo<usize>>::index::{{closure}}::hd9bd1f9708957db3.1491
+                 19 ┊          0.03% ┊    73 ┊  0.13% ┊ <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_str
+                    ┊                ┊    54 ┊  0.09% ┊     <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_str::h940b1386ae3f4147
+                    ┊                ┊    14 ┊  0.02% ┊     <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_str::h0767b084488f159f
+                    ┊                ┊     5 ┊  0.01% ┊     <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_str::h57f5456f6d1b5eb7
+                 17 ┊          0.03% ┊   367 ┊  0.63% ┊ <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_char
+                    ┊                ┊   350 ┊  0.60% ┊     <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_char::h3857faf68988bcc7
+                    ┊                ┊    12 ┊  0.02% ┊     <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_char::hc2c65c2f6506605c
+                    ┊                ┊     5 ┊  0.01% ┊     <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_char::h6892581b60805034
+                 14 ┊          0.02% ┊    21 ┊  0.04% ┊ monos::generic
+                    ┊                ┊     7 ┊  0.01% ┊     monos::generic::h3f709b036579455b
+                    ┊                ┊     7 ┊  0.01% ┊     monos::generic::h750555479e5489a4
+                    ┊                ┊     7 ┊  0.01% ┊     monos::generic::hfe1fd39004fc0e00
+                 13 ┊          0.02% ┊    26 ┊  0.04% ┊ <T as core::any::Any>::get_type_id
+                    ┊                ┊    13 ┊  0.02% ┊     <T as core::any::Any>::get_type_id::h70dbcd8d7607e25f
+                    ┊                ┊    13 ┊  0.02% ┊     <T as core::any::Any>::get_type_id::ha221e40008a49a7a
+                  5 ┊          0.01% ┊   256 ┊  0.44% ┊ core::fmt::Write::write_char
+                    ┊                ┊   251 ┊  0.43% ┊     core::fmt::Write::write_char::hf2fdb3b1239aa837
+                    ┊                ┊     5 ┊  0.01% ┊     core::fmt::Write::write_char::h5d6f077de992701b
+                  0 ┊          0.00% ┊  3350 ┊  5.76% ┊ dlmalloc::dlmalloc::Dlmalloc::malloc
+                    ┊                ┊  3350 ┊  5.76% ┊     dlmalloc::dlmalloc::Dlmalloc::malloc::hb5416e93def64fe7
+                  0 ┊          0.00% ┊  1633 ┊  2.81% ┊ core::fmt::Formatter::pad
+                    ┊                ┊  1633 ┊  2.81% ┊     core::fmt::Formatter::pad::hd38c4d6e1efb341d
+                  0 ┊          0.00% ┊  1483 ┊  2.55% ┊ std::panicking::rust_panic_with_hook
+                    ┊                ┊  1483 ┊  2.55% ┊     std::panicking::rust_panic_with_hook::he8cd48d8bdfe5554
+                  0 ┊          0.00% ┊  1241 ┊  2.13% ┊ core::fmt::Formatter::pad_integral
+                    ┊                ┊  1241 ┊  2.13% ┊     core::fmt::Formatter::pad_integral::h5baf21c51a966f3a
+                  0 ┊          0.00% ┊  1187 ┊  2.04% ┊ core::str::slice_error_fail
+                    ┊                ┊  1187 ┊  2.04% ┊     core::str::slice_error_fail::h09abd70508ac6224
+                  0 ┊          0.00% ┊  1113 ┊  1.91% ┊ core::fmt::write
+                    ┊                ┊  1113 ┊  1.91% ┊     core::fmt::write::hc24fd199dd6d7a6f
+                  0 ┊          0.00% ┊   902 ┊  1.55% ┊ <char as core::fmt::Debug>::fmt
+                    ┊                ┊   902 ┊  1.55% ┊     <char as core::fmt::Debug>::fmt::h46c9e10e3204a725
+                  0 ┊          0.00% ┊   897 ┊  1.54% ┊ dlmalloc::dlmalloc::Dlmalloc::free
+                    ┊                ┊   897 ┊  1.54% ┊     dlmalloc::dlmalloc::Dlmalloc::free::hca49a97af7c495aa
+                  0 ┊          0.00% ┊   728 ┊  1.25% ┊ core::slice::memchr::memchr
+                    ┊                ┊   728 ┊  1.25% ┊     core::slice::memchr::memchr::hbd473f47994473fe
+                  0 ┊          0.00% ┊   702 ┊  1.21% ┊ <core::fmt::builders::PadAdapter<'a> as core::fmt::Write>::write_str
+                    ┊                ┊   702 ┊  1.21% ┊     <core::fmt::builders::PadAdapter<'a> as core::fmt::Write>::write_str::hf1251ddfe5caf5c0
+                  0 ┊          0.00% ┊   657 ┊  1.13% ┊ std::panicking::default_hook::{{closure}}
+                    ┊                ┊   657 ┊  1.13% ┊     std::panicking::default_hook::{{closure}}::h88efaeab38b3bb92
+                  0 ┊          0.00% ┊   638 ┊  1.10% ┊ dlmalloc::dlmalloc::Dlmalloc::dispose_chunk
+                    ┊                ┊   638 ┊  1.10% ┊     dlmalloc::dlmalloc::Dlmalloc::dispose_chunk::hf93802a9a8432d34
+                  0 ┊          0.00% ┊   513 ┊  0.88% ┊ std::thread::Thread::new
+                    ┊                ┊   513 ┊  0.88% ┊     std::thread::Thread::new::hcb7a87467126075e
+                  0 ┊          0.00% ┊   473 ┊  0.81% ┊ <core::alloc::LayoutErr as core::fmt::Debug>::fmt
+                    ┊                ┊   473 ┊  0.81% ┊     <core::alloc::LayoutErr as core::fmt::Debug>::fmt::hfd2b5abe22462496
+                  0 ┊          0.00% ┊   384 ┊  0.66% ┊ std::io::Write::write_fmt
+                    ┊                ┊   384 ┊  0.66% ┊     std::io::Write::write_fmt::h9af1b3f2948b70aa
+                  0 ┊          0.00% ┊   366 ┊  0.63% ┊ dlmalloc::dlmalloc::Dlmalloc::memalign
+                    ┊                ┊   366 ┊  0.63% ┊     dlmalloc::dlmalloc::Dlmalloc::memalign::hd4d61f94fa766d6d
+                  0 ┊          0.00% ┊   358 ┊  0.62% ┊ core::fmt::Formatter::pad_integral::{{closure}}
+                    ┊                ┊   358 ┊  0.62% ┊     core::fmt::Formatter::pad_integral::{{closure}}::hc418afb1063bb9cd
+                  0 ┊          0.00% ┊   350 ┊  0.60% ┊ core::unicode::printable::check
+                    ┊                ┊   350 ┊  0.60% ┊     core::unicode::printable::check::h25f5f3b248ff4de9
+                  0 ┊          0.00% ┊   346 ┊  0.59% ┊ core::fmt::builders::DebugTuple::field
+                    ┊                ┊   346 ┊  0.59% ┊     core::fmt::builders::DebugTuple::field::hb0accc3621cba4bb
+                  0 ┊          0.00% ┊   332 ┊  0.57% ┊ dlmalloc::dlmalloc::Dlmalloc::insert_large_chunk
+                    ┊                ┊   332 ┊  0.57% ┊     dlmalloc::dlmalloc::Dlmalloc::insert_large_chunk::hab943d3cb50736d3
+                  0 ┊          0.00% ┊   311 ┊  0.53% ┊ core::fmt::num::<impl core::fmt::Display for u32>::fmt
+                    ┊                ┊   311 ┊  0.53% ┊     core::fmt::num::<impl core::fmt::Display for u32>::fmt::hf9b023faccafcd44
+                  0 ┊          0.00% ┊   311 ┊  0.53% ┊ core::fmt::num::<impl core::fmt::Display for usize>::fmt
+                    ┊                ┊   311 ┊  0.53% ┊     core::fmt::num::<impl core::fmt::Display for usize>::fmt::hdfa35b6f37f7920b
+                  0 ┊          0.00% ┊   309 ┊  0.53% ┊ dlmalloc::dlmalloc::Dlmalloc::unlink_large_chunk
+                    ┊                ┊   309 ┊  0.53% ┊     dlmalloc::dlmalloc::Dlmalloc::unlink_large_chunk::h9ce5e82f14cb088c
+                  0 ┊          0.00% ┊   294 ┊  0.51% ┊ core::fmt::num::<impl core::fmt::Debug for usize>::fmt
+                    ┊                ┊   294 ┊  0.51% ┊     core::fmt::num::<impl core::fmt::Debug for usize>::fmt::he564909c39b6d025.1723
+                  0 ┊          0.00% ┊   288 ┊  0.49% ┊ <std::thread::local::os::Key<T>>::get
+                    ┊                ┊   288 ┊  0.49% ┊     <std::thread::local::os::Key<T>>::get::hb1c0b3c102520e8e
+                  0 ┊          0.00% ┊   288 ┊  0.49% ┊ std::panicking::LOCAL_STDERR::__getit
+                    ┊                ┊   288 ┊  0.49% ┊     std::panicking::LOCAL_STDERR::__getit::h8fba88afdc9be965
+                  0 ┊          0.00% ┊   288 ┊  0.49% ┊ std::sys_common::thread_info::THREAD_INFO::__getit
+                    ┊                ┊   288 ┊  0.49% ┊     std::sys_common::thread_info::THREAD_INFO::__getit::hd2f70e636773d5bb
+                  0 ┊          0.00% ┊   218 ┊  0.37% ┊ alloc::slice::merge_sort::collapse
+                    ┊                ┊   218 ┊  0.37% ┊     alloc::slice::merge_sort::collapse::h7652880473a820fb
+                  0 ┊          0.00% ┊   187 ┊  0.32% ┊ core::fmt::builders::DebugTuple::finish
+                    ┊                ┊   187 ┊  0.32% ┊     core::fmt::builders::DebugTuple::finish::h4b6f3588cb34c729
+                  0 ┊          0.00% ┊   173 ┊  0.30% ┊ std::panicking::begin_panic_fmt
+                    ┊                ┊   173 ┊  0.30% ┊     std::panicking::begin_panic_fmt::h42619bb35aa26579
+                  0 ┊          0.00% ┊   168 ┊  0.29% ┊ core::unicode::printable::is_printable
+                    ┊                ┊   168 ┊  0.29% ┊     core::unicode::printable::is_printable::h9244f217c062b153
+                  0 ┊          0.00% ┊   158 ┊  0.27% ┊ std::sys_common::util::dumb_print
+                    ┊                ┊   158 ┊  0.27% ┊     std::sys_common::util::dumb_print::h8471f6b6b2efd084
+                  0 ┊          0.00% ┊   154 ┊  0.26% ┊ core::alloc::Layout::repeat
+                    ┊                ┊   154 ┊  0.26% ┊     core::alloc::Layout::repeat::h530ac3db187ac797
+                  0 ┊          0.00% ┊   147 ┊  0.25% ┊ <core::ops::range::Range<Idx> as core::fmt::Debug>::fmt
+                    ┊                ┊   147 ┊  0.25% ┊     <core::ops::range::Range<Idx> as core::fmt::Debug>::fmt::h7062aec4a4b8faad
+                  0 ┊          0.00% ┊   133 ┊  0.23% ┊ core::slice::slice_index_len_fail
+                    ┊                ┊   133 ┊  0.23% ┊     core::slice::slice_index_len_fail::hf5ae4a5ffda80b38
+                  0 ┊          0.00% ┊   133 ┊  0.23% ┊ core::slice::slice_index_order_fail
+                    ┊                ┊   133 ┊  0.23% ┊     core::slice::slice_index_order_fail::ha84da396d40170b0
+                  0 ┊          0.00% ┊   132 ┊  0.23% ┊ core::panicking::panic_bounds_check
+                    ┊                ┊   132 ┊  0.23% ┊     core::panicking::panic_bounds_check::h63ad503ebe07f604
+                  0 ┊          0.00% ┊   130 ┊  0.22% ┊ <alloc::raw_vec::RawVec<T, A>>::reserve
+                    ┊                ┊   130 ┊  0.22% ┊     <alloc::raw_vec::RawVec<T, A>>::reserve::h77c53c3e5b764505
+                  0 ┊          0.00% ┊   120 ┊  0.21% ┊ <std::ffi::c_str::NulError as core::fmt::Debug>::fmt
+                    ┊                ┊   120 ┊  0.21% ┊     <std::ffi::c_str::NulError as core::fmt::Debug>::fmt::hd213df2c4c15ea9b
+                  0 ┊          0.00% ┊   110 ┊  0.19% ┊ core::option::expect_failed
+                    ┊                ┊   110 ┊  0.19% ┊     core::option::expect_failed::ha1e19f3be1783d86
+                  0 ┊          0.00% ┊   109 ┊  0.19% ┊ <alloc::raw_vec::RawVec<T, A>>::reserve_exact
+                    ┊                ┊   109 ┊  0.19% ┊     <alloc::raw_vec::RawVec<T, A>>::reserve_exact::h90209384f3b9be08
+                  0 ┊          0.00% ┊   103 ┊  0.18% ┊ core::panicking::panic
+                    ┊                ┊   103 ┊  0.18% ┊     core::panicking::panic::hd6b1565e097d11be
+                  0 ┊          0.00% ┊    96 ┊  0.16% ┊ <alloc::arc::Arc<T>>::drop_slow
+                    ┊                ┊    96 ┊  0.16% ┊     <alloc::arc::Arc<T>>::drop_slow::hab85f37fa5d78c06
+                  0 ┊          0.00% ┊    96 ┊  0.16% ┊ <std::error::<impl core::convert::From<alloc::string::String> for alloc::boxed::Box<std::error::Error + core::marker::Sync + core::marker::Send + 'static>>::from::StringError as core::fmt::Debug>::fmt
+                    ┊                ┊    96 ┊  0.16% ┊     <std::error::<impl core::convert::From<alloc::string::String> for alloc::boxed::Box<std::error::Error + core::marker::Sync + core::marker::Send + 'static>>::from::StringError as core::fmt::Debug>::fmt::hf81d6ec3ed3cf437
+                  0 ┊          0.00% ┊    87 ┊  0.15% ┊ std::io::impls::<impl std::io::Write for &'a mut W>::write_fmt
+                    ┊                ┊    87 ┊  0.15% ┊     std::io::impls::<impl std::io::Write for &'a mut W>::write_fmt::hdc863fd6486416b4
+                  0 ┊          0.00% ┊    76 ┊  0.13% ┊ <alloc::string::String as core::convert::From<&'a str>>::from
+                    ┊                ┊    76 ┊  0.13% ┊     <alloc::string::String as core::convert::From<&'a str>>::from::h71d62dd67534ae67
+                  0 ┊          0.00% ┊    73 ┊  0.13% ┊ <alloc::vec::Vec<T>>::remove
+                    ┊                ┊    73 ┊  0.13% ┊     <alloc::vec::Vec<T>>::remove::hba13f8aae5697111
+                  0 ┊          0.00% ┊    62 ┊  0.11% ┊ core::panicking::panic_fmt
+                    ┊                ┊    62 ┊  0.11% ┊     core::panicking::panic_fmt::h2ddf6ebf35664a22
+                  0 ┊          0.00% ┊    61 ┊  0.10% ┊ <core::alloc::CollectionAllocErr as core::fmt::Debug>::fmt
+                    ┊                ┊    61 ┊  0.10% ┊     <core::alloc::CollectionAllocErr as core::fmt::Debug>::fmt::h1e612cc5b402d018
+                  0 ┊          0.00% ┊    44 ┊  0.08% ┊ std::panicking::begin_panic
+                    ┊                ┊    44 ┊  0.08% ┊     std::panicking::begin_panic::h1c67cf480c82ca41
+                  0 ┊          0.00% ┊    42 ┊  0.07% ┊ <alloc::vec::Vec<T> as core::ops::index::Index<I>>::index
+                    ┊                ┊    42 ┊  0.07% ┊     <alloc::vec::Vec<T> as core::ops::index::Index<I>>::index::h0e2d043e9c4be2a4
+                  0 ┊          0.00% ┊    42 ┊  0.07% ┊ <alloc::vec::Vec<T> as core::ops::index::IndexMut<I>>::index_mut
+                    ┊                ┊    42 ┊  0.07% ┊     <alloc::vec::Vec<T> as core::ops::index::IndexMut<I>>::index_mut::he65e880dfe71ede7
+                  0 ┊          0.00% ┊    39 ┊  0.07% ┊ core::str::traits::<impl core::slice::SliceIndex<str> for core::ops::range::Range<usize>>::index::{{closure}}
+                    ┊                ┊    39 ┊  0.07% ┊     core::str::traits::<impl core::slice::SliceIndex<str> for core::ops::range::Range<usize>>::index::{{closure}}::h60168465cb72d0d1.1520
+                  0 ┊          0.00% ┊    31 ┊  0.05% ┊ <core::result::Result<T, E>>::unwrap
+                    ┊                ┊    31 ┊  0.05% ┊     <core::result::Result<T, E>>::unwrap::h6cc6e55b8a35b2a0
+                  0 ┊          0.00% ┊    27 ┊  0.05% ┊ <core::cell::BorrowError as core::fmt::Debug>::fmt
+                    ┊                ┊    27 ┊  0.05% ┊     <core::cell::BorrowError as core::fmt::Debug>::fmt::hf74aff9660f52336
+                  0 ┊          0.00% ┊    27 ┊  0.05% ┊ <core::cell::BorrowMutError as core::fmt::Debug>::fmt
+                    ┊                ┊    27 ┊  0.05% ┊     <core::cell::BorrowMutError as core::fmt::Debug>::fmt::h7d6c4aa36e2bbb3a
+                  0 ┊          0.00% ┊    27 ┊  0.05% ┊ <std::thread::local::AccessError as core::fmt::Debug>::fmt
+                    ┊                ┊    27 ┊  0.05% ┊     <std::thread::local::AccessError as core::fmt::Debug>::fmt::h468179781fdd317a
+                  0 ┊          0.00% ┊    26 ┊  0.04% ┊ <core::result::Result<T, E>>::expect
+                    ┊                ┊    26 ┊  0.04% ┊     <core::result::Result<T, E>>::expect::h43eea250881e7715
+                  0 ┊          0.00% ┊    23 ┊  0.04% ┊ <std::error::<impl core::convert::From<alloc::string::String> for alloc::boxed::Box<std::error::Error + core::marker::Sync + core::marker::Send + 'static>>::from::StringError as std::error::Error>::description
+                    ┊                ┊    23 ┊  0.04% ┊     <std::error::<impl core::convert::From<alloc::string::String> for alloc::boxed::Box<std::error::Error + core::marker::Sync + core::marker::Send + 'static>>::from::StringError as std::error::Error>::description::h81f56e02f5e7f796
+                  0 ┊          0.00% ┊    19 ┊  0.03% ┊ <core::option::Option<T>>::expect
+                    ┊                ┊    19 ┊  0.03% ┊     <core::option::Option<T>>::expect::h53ba5982e622ab98
+                  0 ┊          0.00% ┊    17 ┊  0.03% ┊ <std::error::<impl core::convert::From<alloc::string::String> for alloc::boxed::Box<std::error::Error + core::marker::Sync + core::marker::Send + 'static>>::from::StringError as core::fmt::Display>::fmt
+                    ┊                ┊    17 ┊  0.03% ┊     <std::error::<impl core::convert::From<alloc::string::String> for alloc::boxed::Box<std::error::Error + core::marker::Sync + core::marker::Send + 'static>>::from::StringError as core::fmt::Display>::fmt::h289d4f072dbab567
+                  0 ┊          0.00% ┊    17 ┊  0.03% ┊ std::io::impls::<impl std::io::Write for &'a mut W>::write
+                    ┊                ┊    17 ┊  0.03% ┊     std::io::impls::<impl std::io::Write for &'a mut W>::write::hb0915e9baef1a41b
+                  0 ┊          0.00% ┊    14 ┊  0.02% ┊ std::error::Error::type_id
+                    ┊                ┊    14 ┊  0.02% ┊     std::error::Error::type_id::hc259f20f01bc805f
+                  0 ┊          0.00% ┊    10 ┊  0.02% ┊ std::error::Error::cause
+                    ┊                ┊    10 ┊  0.02% ┊     std::error::Error::cause::h4980985f30856d32
+                  0 ┊          0.00% ┊    10 ┊  0.02% ┊ std::io::impls::<impl std::io::Write for &'a mut W>::flush
+                    ┊                ┊    10 ┊  0.02% ┊     std::io::impls::<impl std::io::Write for &'a mut W>::flush::h19ff0277e6b3d742
+                  0 ┊          0.00% ┊    10 ┊  0.02% ┊ std::io::impls::<impl std::io::Write for &'a mut W>::write_all
+                    ┊                ┊    10 ┊  0.02% ┊     std::io::impls::<impl std::io::Write for &'a mut W>::write_all::hcfa3a97487c6f2fb
+                  0 ┊          0.00% ┊     9 ┊  0.02% ┊ core::fmt::ArgumentV1::show_usize
+                    ┊                ┊     9 ┊  0.02% ┊     core::fmt::ArgumentV1::show_usize::hfae8c3232f8e141e
+                  0 ┊          0.00% ┊     5 ┊  0.01% ┊ <monos::One as monos::Code>::code
+                    ┊                ┊     5 ┊  0.01% ┊     <monos::One as monos::Code>::code::h94feb5b1732d1e4b
+                  0 ┊          0.00% ┊     5 ┊  0.01% ┊ <monos::Two as monos::Code>::code
+                    ┊                ┊     5 ┊  0.01% ┊     <monos::Two as monos::Code>::code::h394b28ea75b29629
+                  0 ┊          0.00% ┊     5 ┊  0.01% ┊ <monos::Zero as monos::Code>::code
+                    ┊                ┊     5 ┊  0.01% ┊     <monos::Zero as monos::Code>::code::h86bfbb5b849aa69f
+                  0 ┊          0.00% ┊     5 ┊  0.01% ┊ <std::io::Write::write_fmt::Adaptor<'a, T> as core::fmt::Write>::write_str
+                    ┊                ┊     5 ┊  0.01% ┊     <std::io::Write::write_fmt::Adaptor<'a, T> as core::fmt::Write>::write_str::h1fcd48dcfdd79843
+               6459 ┊         11.10% ┊ 34980 ┊ 60.10% ┊ Σ [237 Total Rows]

--- a/twiggy/tests/expectations/monos_all_generics
+++ b/twiggy/tests/expectations/monos_all_generics
@@ -1,0 +1,238 @@
+ Apprx. Bloat Bytes │ Apprx. Bloat % │ Bytes │ %      │ Monomorphizations
+────────────────────┼────────────────┼───────┼────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+               1977 ┊          3.40% ┊  3003 ┊  5.16% ┊ alloc::slice::merge_sort
+                    ┊                ┊  1026 ┊  1.76% ┊     alloc::slice::merge_sort::hb3d195f9800bdad6
+                    ┊                ┊  1026 ┊  1.76% ┊     alloc::slice::merge_sort::hfcf2318d7dc71d03
+                    ┊                ┊   951 ┊  1.63% ┊     alloc::slice::merge_sort::hcfca67f5c75a52ef
+               1302 ┊          2.24% ┊  3996 ┊  6.87% ┊ <&'a T as core::fmt::Debug>::fmt
+                    ┊                ┊  2694 ┊  4.63% ┊     <&'a T as core::fmt::Debug>::fmt::h1c27955d8de3ff17
+                    ┊                ┊   568 ┊  0.98% ┊     <&'a T as core::fmt::Debug>::fmt::hea6a77c4dcddb7ac
+                    ┊                ┊   433 ┊  0.74% ┊     <&'a T as core::fmt::Debug>::fmt::hfbacf6f5c9f53bb2
+                    ┊                ┊   301 ┊  0.52% ┊     <&'a T as core::fmt::Debug>::fmt::h199e8e1c5752e6f1
+                973 ┊          1.67% ┊  1118 ┊  1.92% ┊ core::result::unwrap_failed
+                    ┊                ┊   145 ┊  0.25% ┊     core::result::unwrap_failed::h137aa4f433aba1a9
+                    ┊                ┊   145 ┊  0.25% ┊     core::result::unwrap_failed::h4cc73eb9bf19ce32
+                    ┊                ┊   145 ┊  0.25% ┊     core::result::unwrap_failed::h9bd27c3a9ad7c001
+                    ┊                ┊   138 ┊  0.24% ┊     core::result::unwrap_failed::h9a7678774db14d67
+                    ┊                ┊   138 ┊  0.24% ┊     core::result::unwrap_failed::ha3e58cfc7f422ab4
+                    ┊                ┊   138 ┊  0.24% ┊     core::result::unwrap_failed::ha7651fcaac40f701
+                    ┊                ┊   138 ┊  0.24% ┊     core::result::unwrap_failed::hcb258ce32bda3d85
+                    ┊                ┊   131 ┊  0.23% ┊     core::result::unwrap_failed::hcfddf900474e698a
+                558 ┊          0.96% ┊   714 ┊  1.23% ┊ <alloc::raw_vec::RawVec<T, A>>::double
+                    ┊                ┊   156 ┊  0.27% ┊     <alloc::raw_vec::RawVec<T, A>>::double::h28f86621ee2a10aa
+                    ┊                ┊   156 ┊  0.27% ┊     <alloc::raw_vec::RawVec<T, A>>::double::h956450b93bdc9e1e
+                    ┊                ┊   156 ┊  0.27% ┊     <alloc::raw_vec::RawVec<T, A>>::double::hcb2fb5861b96a3b0
+                    ┊                ┊   147 ┊  0.25% ┊     <alloc::raw_vec::RawVec<T, A>>::double::ha715b4e5cc3c60ae
+                    ┊                ┊    99 ┊  0.17% ┊     <alloc::raw_vec::RawVec<T, A>>::double::h77ff8547127c5db2
+                512 ┊          0.88% ┊   798 ┊  1.37% ┊ std::thread::local::os::destroy_value
+                    ┊                ┊   286 ┊  0.49% ┊     std::thread::local::os::destroy_value::hca8124786bee4a79
+                    ┊                ┊   281 ┊  0.48% ┊     std::thread::local::os::destroy_value::h094cf4f2a025ba2b
+                    ┊                ┊   231 ┊  0.40% ┊     std::thread::local::os::destroy_value::h453d41f6c315da32
+                234 ┊          0.40% ┊   354 ┊  0.61% ┊ alloc::slice::insert_head
+                    ┊                ┊   120 ┊  0.21% ┊     alloc::slice::insert_head::h2cdb84a455761146
+                    ┊                ┊   120 ┊  0.21% ┊     alloc::slice::insert_head::haf6e08236bab8bde
+                    ┊                ┊   114 ┊  0.20% ┊     alloc::slice::insert_head::hed0e79da03eeec8b
+                196 ┊          0.34% ┊   294 ┊  0.51% ┊ <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_fmt
+                    ┊                ┊    98 ┊  0.17% ┊     <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_fmt::h1b74a5fafe15c8eb
+                    ┊                ┊    98 ┊  0.17% ┊     <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_fmt::h24034d1c07bfae93
+                    ┊                ┊    98 ┊  0.17% ┊     <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_fmt::h5ebed3e159974658
+                195 ┊          0.34% ┊   270 ┊  0.46% ┊ <alloc::vec::Vec<T>>::push
+                    ┊                ┊    75 ┊  0.13% ┊     <alloc::vec::Vec<T>>::push::h98b02eda22d1ca25
+                    ┊                ┊    66 ┊  0.11% ┊     <alloc::vec::Vec<T>>::push::h5729b9e7651ef67b
+                    ┊                ┊    66 ┊  0.11% ┊     <alloc::vec::Vec<T>>::push::hc927b4bedb35b00d
+                    ┊                ┊    63 ┊  0.11% ┊     <alloc::vec::Vec<T>>::push::h9415ef699ccc65d8
+                119 ┊          0.20% ┊   180 ┊  0.31% ┊ <core::ops::range::Range<usize> as core::slice::SliceIndex<[T]>>::index_mut
+                    ┊                ┊    61 ┊  0.10% ┊     <core::ops::range::Range<usize> as core::slice::SliceIndex<[T]>>::index_mut::hba42cce6d0c0099b
+                    ┊                ┊    61 ┊  0.10% ┊     <core::ops::range::Range<usize> as core::slice::SliceIndex<[T]>>::index_mut::hbf8fcfe76c1f6657
+                    ┊                ┊    58 ┊  0.10% ┊     <core::ops::range::Range<usize> as core::slice::SliceIndex<[T]>>::index_mut::h1c053f01b6f95d93
+                 95 ┊          0.16% ┊   190 ┊  0.33% ┊ core::fmt::Write::write_fmt
+                    ┊                ┊    95 ┊  0.16% ┊     core::fmt::Write::write_fmt::ha5ae3249cacba520
+                    ┊                ┊    95 ┊  0.16% ┊     core::fmt::Write::write_fmt::hef4632e1398f5ac8
+                 90 ┊          0.15% ┊   167 ┊  0.29% ┊ core::ptr::drop_in_place
+                    ┊                ┊    77 ┊  0.13% ┊     core::ptr::drop_in_place::h494c395f6e046dd8
+                    ┊                ┊    21 ┊  0.04% ┊     core::ptr::drop_in_place::h42ed7c6a38cb8e07
+                    ┊                ┊    21 ┊  0.04% ┊     core::ptr::drop_in_place::h4ca61ce56a679223
+                    ┊                ┊    21 ┊  0.04% ┊     core::ptr::drop_in_place::ha01a5d42ad694a80.222
+                    ┊                ┊     3 ┊  0.01% ┊     core::ptr::drop_in_place::h17156ca791bccf59.513
+                    ┊                ┊     3 ┊  0.01% ┊     core::ptr::drop_in_place::h1c915609313c62ad
+                    ┊                ┊     3 ┊  0.01% ┊     core::ptr::drop_in_place::h3eafb424d17eed5a
+                    ┊                ┊     3 ┊  0.01% ┊     core::ptr::drop_in_place::h5fe186521e50398c
+                    ┊                ┊     3 ┊  0.01% ┊     core::ptr::drop_in_place::h866e65b55bb41ec8
+                    ┊                ┊     3 ┊  0.01% ┊     core::ptr::drop_in_place::h90b51321c83f0b52
+                    ┊                ┊     9 ┊  0.02% ┊     ... and 3 more.
+                 51 ┊          0.09% ┊    68 ┊  0.12% ┊ <&'a T as core::fmt::Display>::fmt
+                    ┊                ┊    17 ┊  0.03% ┊     <&'a T as core::fmt::Display>::fmt::h176bc0565ce2f755
+                    ┊                ┊    17 ┊  0.03% ┊     <&'a T as core::fmt::Display>::fmt::h926f24fdf869c3d4
+                    ┊                ┊    17 ┊  0.03% ┊     <&'a T as core::fmt::Display>::fmt::h9a5e4ca609ef3195
+                    ┊                ┊    17 ┊  0.03% ┊     <&'a T as core::fmt::Display>::fmt::hfd15206c852ff237
+                 39 ┊          0.07% ┊    78 ┊  0.13% ┊ core::str::traits::<impl core::slice::SliceIndex<str> for core::ops::range::RangeFrom<usize>>::index::{{closure}}
+                    ┊                ┊    39 ┊  0.07% ┊     core::str::traits::<impl core::slice::SliceIndex<str> for core::ops::range::RangeFrom<usize>>::index::{{closure}}::h551234547249438f
+                    ┊                ┊    39 ┊  0.07% ┊     core::str::traits::<impl core::slice::SliceIndex<str> for core::ops::range::RangeFrom<usize>>::index::{{closure}}::h551234547249438f.1519
+                 30 ┊          0.05% ┊    45 ┊  0.08% ┊ <alloc::raw_vec::RawVec<T, A> as core::ops::drop::Drop>::drop
+                    ┊                ┊    15 ┊  0.03% ┊     <alloc::raw_vec::RawVec<T, A> as core::ops::drop::Drop>::drop::h420ff33e8bc0de30
+                    ┊                ┊    15 ┊  0.03% ┊     <alloc::raw_vec::RawVec<T, A> as core::ops::drop::Drop>::drop::hab66cea5bda1ed02
+                    ┊                ┊    15 ┊  0.03% ┊     <alloc::raw_vec::RawVec<T, A> as core::ops::drop::Drop>::drop::hbe243f4c44295f3d
+                 20 ┊          0.03% ┊    40 ┊  0.07% ┊ core::str::traits::<impl core::slice::SliceIndex<str> for core::ops::range::RangeTo<usize>>::index::{{closure}}
+                    ┊                ┊    20 ┊  0.03% ┊     core::str::traits::<impl core::slice::SliceIndex<str> for core::ops::range::RangeTo<usize>>::index::{{closure}}::hd9bd1f9708957db3
+                    ┊                ┊    20 ┊  0.03% ┊     core::str::traits::<impl core::slice::SliceIndex<str> for core::ops::range::RangeTo<usize>>::index::{{closure}}::hd9bd1f9708957db3.1491
+                 19 ┊          0.03% ┊    73 ┊  0.13% ┊ <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_str
+                    ┊                ┊    54 ┊  0.09% ┊     <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_str::h940b1386ae3f4147
+                    ┊                ┊    14 ┊  0.02% ┊     <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_str::h0767b084488f159f
+                    ┊                ┊     5 ┊  0.01% ┊     <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_str::h57f5456f6d1b5eb7
+                 17 ┊          0.03% ┊   367 ┊  0.63% ┊ <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_char
+                    ┊                ┊   350 ┊  0.60% ┊     <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_char::h3857faf68988bcc7
+                    ┊                ┊    12 ┊  0.02% ┊     <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_char::hc2c65c2f6506605c
+                    ┊                ┊     5 ┊  0.01% ┊     <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_char::h6892581b60805034
+                 14 ┊          0.02% ┊    21 ┊  0.04% ┊ monos::generic
+                    ┊                ┊     7 ┊  0.01% ┊     monos::generic::h3f709b036579455b
+                    ┊                ┊     7 ┊  0.01% ┊     monos::generic::h750555479e5489a4
+                    ┊                ┊     7 ┊  0.01% ┊     monos::generic::hfe1fd39004fc0e00
+                 13 ┊          0.02% ┊    26 ┊  0.04% ┊ <T as core::any::Any>::get_type_id
+                    ┊                ┊    13 ┊  0.02% ┊     <T as core::any::Any>::get_type_id::h70dbcd8d7607e25f
+                    ┊                ┊    13 ┊  0.02% ┊     <T as core::any::Any>::get_type_id::ha221e40008a49a7a
+                  5 ┊          0.01% ┊   256 ┊  0.44% ┊ core::fmt::Write::write_char
+                    ┊                ┊   251 ┊  0.43% ┊     core::fmt::Write::write_char::hf2fdb3b1239aa837
+                    ┊                ┊     5 ┊  0.01% ┊     core::fmt::Write::write_char::h5d6f077de992701b
+                  0 ┊          0.00% ┊  3350 ┊  5.76% ┊ dlmalloc::dlmalloc::Dlmalloc::malloc
+                    ┊                ┊  3350 ┊  5.76% ┊     dlmalloc::dlmalloc::Dlmalloc::malloc::hb5416e93def64fe7
+                  0 ┊          0.00% ┊  1633 ┊  2.81% ┊ core::fmt::Formatter::pad
+                    ┊                ┊  1633 ┊  2.81% ┊     core::fmt::Formatter::pad::hd38c4d6e1efb341d
+                  0 ┊          0.00% ┊  1483 ┊  2.55% ┊ std::panicking::rust_panic_with_hook
+                    ┊                ┊  1483 ┊  2.55% ┊     std::panicking::rust_panic_with_hook::he8cd48d8bdfe5554
+                  0 ┊          0.00% ┊  1241 ┊  2.13% ┊ core::fmt::Formatter::pad_integral
+                    ┊                ┊  1241 ┊  2.13% ┊     core::fmt::Formatter::pad_integral::h5baf21c51a966f3a
+                  0 ┊          0.00% ┊  1187 ┊  2.04% ┊ core::str::slice_error_fail
+                    ┊                ┊  1187 ┊  2.04% ┊     core::str::slice_error_fail::h09abd70508ac6224
+                  0 ┊          0.00% ┊  1113 ┊  1.91% ┊ core::fmt::write
+                    ┊                ┊  1113 ┊  1.91% ┊     core::fmt::write::hc24fd199dd6d7a6f
+                  0 ┊          0.00% ┊   902 ┊  1.55% ┊ <char as core::fmt::Debug>::fmt
+                    ┊                ┊   902 ┊  1.55% ┊     <char as core::fmt::Debug>::fmt::h46c9e10e3204a725
+                  0 ┊          0.00% ┊   897 ┊  1.54% ┊ dlmalloc::dlmalloc::Dlmalloc::free
+                    ┊                ┊   897 ┊  1.54% ┊     dlmalloc::dlmalloc::Dlmalloc::free::hca49a97af7c495aa
+                  0 ┊          0.00% ┊   728 ┊  1.25% ┊ core::slice::memchr::memchr
+                    ┊                ┊   728 ┊  1.25% ┊     core::slice::memchr::memchr::hbd473f47994473fe
+                  0 ┊          0.00% ┊   702 ┊  1.21% ┊ <core::fmt::builders::PadAdapter<'a> as core::fmt::Write>::write_str
+                    ┊                ┊   702 ┊  1.21% ┊     <core::fmt::builders::PadAdapter<'a> as core::fmt::Write>::write_str::hf1251ddfe5caf5c0
+                  0 ┊          0.00% ┊   657 ┊  1.13% ┊ std::panicking::default_hook::{{closure}}
+                    ┊                ┊   657 ┊  1.13% ┊     std::panicking::default_hook::{{closure}}::h88efaeab38b3bb92
+                  0 ┊          0.00% ┊   638 ┊  1.10% ┊ dlmalloc::dlmalloc::Dlmalloc::dispose_chunk
+                    ┊                ┊   638 ┊  1.10% ┊     dlmalloc::dlmalloc::Dlmalloc::dispose_chunk::hf93802a9a8432d34
+                  0 ┊          0.00% ┊   513 ┊  0.88% ┊ std::thread::Thread::new
+                    ┊                ┊   513 ┊  0.88% ┊     std::thread::Thread::new::hcb7a87467126075e
+                  0 ┊          0.00% ┊   473 ┊  0.81% ┊ <core::alloc::LayoutErr as core::fmt::Debug>::fmt
+                    ┊                ┊   473 ┊  0.81% ┊     <core::alloc::LayoutErr as core::fmt::Debug>::fmt::hfd2b5abe22462496
+                  0 ┊          0.00% ┊   384 ┊  0.66% ┊ std::io::Write::write_fmt
+                    ┊                ┊   384 ┊  0.66% ┊     std::io::Write::write_fmt::h9af1b3f2948b70aa
+                  0 ┊          0.00% ┊   366 ┊  0.63% ┊ dlmalloc::dlmalloc::Dlmalloc::memalign
+                    ┊                ┊   366 ┊  0.63% ┊     dlmalloc::dlmalloc::Dlmalloc::memalign::hd4d61f94fa766d6d
+                  0 ┊          0.00% ┊   358 ┊  0.62% ┊ core::fmt::Formatter::pad_integral::{{closure}}
+                    ┊                ┊   358 ┊  0.62% ┊     core::fmt::Formatter::pad_integral::{{closure}}::hc418afb1063bb9cd
+                  0 ┊          0.00% ┊   350 ┊  0.60% ┊ core::unicode::printable::check
+                    ┊                ┊   350 ┊  0.60% ┊     core::unicode::printable::check::h25f5f3b248ff4de9
+                  0 ┊          0.00% ┊   346 ┊  0.59% ┊ core::fmt::builders::DebugTuple::field
+                    ┊                ┊   346 ┊  0.59% ┊     core::fmt::builders::DebugTuple::field::hb0accc3621cba4bb
+                  0 ┊          0.00% ┊   332 ┊  0.57% ┊ dlmalloc::dlmalloc::Dlmalloc::insert_large_chunk
+                    ┊                ┊   332 ┊  0.57% ┊     dlmalloc::dlmalloc::Dlmalloc::insert_large_chunk::hab943d3cb50736d3
+                  0 ┊          0.00% ┊   311 ┊  0.53% ┊ core::fmt::num::<impl core::fmt::Display for u32>::fmt
+                    ┊                ┊   311 ┊  0.53% ┊     core::fmt::num::<impl core::fmt::Display for u32>::fmt::hf9b023faccafcd44
+                  0 ┊          0.00% ┊   311 ┊  0.53% ┊ core::fmt::num::<impl core::fmt::Display for usize>::fmt
+                    ┊                ┊   311 ┊  0.53% ┊     core::fmt::num::<impl core::fmt::Display for usize>::fmt::hdfa35b6f37f7920b
+                  0 ┊          0.00% ┊   309 ┊  0.53% ┊ dlmalloc::dlmalloc::Dlmalloc::unlink_large_chunk
+                    ┊                ┊   309 ┊  0.53% ┊     dlmalloc::dlmalloc::Dlmalloc::unlink_large_chunk::h9ce5e82f14cb088c
+                  0 ┊          0.00% ┊   294 ┊  0.51% ┊ core::fmt::num::<impl core::fmt::Debug for usize>::fmt
+                    ┊                ┊   294 ┊  0.51% ┊     core::fmt::num::<impl core::fmt::Debug for usize>::fmt::he564909c39b6d025.1723
+                  0 ┊          0.00% ┊   288 ┊  0.49% ┊ <std::thread::local::os::Key<T>>::get
+                    ┊                ┊   288 ┊  0.49% ┊     <std::thread::local::os::Key<T>>::get::hb1c0b3c102520e8e
+                  0 ┊          0.00% ┊   288 ┊  0.49% ┊ std::panicking::LOCAL_STDERR::__getit
+                    ┊                ┊   288 ┊  0.49% ┊     std::panicking::LOCAL_STDERR::__getit::h8fba88afdc9be965
+                  0 ┊          0.00% ┊   288 ┊  0.49% ┊ std::sys_common::thread_info::THREAD_INFO::__getit
+                    ┊                ┊   288 ┊  0.49% ┊     std::sys_common::thread_info::THREAD_INFO::__getit::hd2f70e636773d5bb
+                  0 ┊          0.00% ┊   218 ┊  0.37% ┊ alloc::slice::merge_sort::collapse
+                    ┊                ┊   218 ┊  0.37% ┊     alloc::slice::merge_sort::collapse::h7652880473a820fb
+                  0 ┊          0.00% ┊   187 ┊  0.32% ┊ core::fmt::builders::DebugTuple::finish
+                    ┊                ┊   187 ┊  0.32% ┊     core::fmt::builders::DebugTuple::finish::h4b6f3588cb34c729
+                  0 ┊          0.00% ┊   173 ┊  0.30% ┊ std::panicking::begin_panic_fmt
+                    ┊                ┊   173 ┊  0.30% ┊     std::panicking::begin_panic_fmt::h42619bb35aa26579
+                  0 ┊          0.00% ┊   168 ┊  0.29% ┊ core::unicode::printable::is_printable
+                    ┊                ┊   168 ┊  0.29% ┊     core::unicode::printable::is_printable::h9244f217c062b153
+                  0 ┊          0.00% ┊   158 ┊  0.27% ┊ std::sys_common::util::dumb_print
+                    ┊                ┊   158 ┊  0.27% ┊     std::sys_common::util::dumb_print::h8471f6b6b2efd084
+                  0 ┊          0.00% ┊   154 ┊  0.26% ┊ core::alloc::Layout::repeat
+                    ┊                ┊   154 ┊  0.26% ┊     core::alloc::Layout::repeat::h530ac3db187ac797
+                  0 ┊          0.00% ┊   147 ┊  0.25% ┊ <core::ops::range::Range<Idx> as core::fmt::Debug>::fmt
+                    ┊                ┊   147 ┊  0.25% ┊     <core::ops::range::Range<Idx> as core::fmt::Debug>::fmt::h7062aec4a4b8faad
+                  0 ┊          0.00% ┊   133 ┊  0.23% ┊ core::slice::slice_index_len_fail
+                    ┊                ┊   133 ┊  0.23% ┊     core::slice::slice_index_len_fail::hf5ae4a5ffda80b38
+                  0 ┊          0.00% ┊   133 ┊  0.23% ┊ core::slice::slice_index_order_fail
+                    ┊                ┊   133 ┊  0.23% ┊     core::slice::slice_index_order_fail::ha84da396d40170b0
+                  0 ┊          0.00% ┊   132 ┊  0.23% ┊ core::panicking::panic_bounds_check
+                    ┊                ┊   132 ┊  0.23% ┊     core::panicking::panic_bounds_check::h63ad503ebe07f604
+                  0 ┊          0.00% ┊   130 ┊  0.22% ┊ <alloc::raw_vec::RawVec<T, A>>::reserve
+                    ┊                ┊   130 ┊  0.22% ┊     <alloc::raw_vec::RawVec<T, A>>::reserve::h77c53c3e5b764505
+                  0 ┊          0.00% ┊   120 ┊  0.21% ┊ <std::ffi::c_str::NulError as core::fmt::Debug>::fmt
+                    ┊                ┊   120 ┊  0.21% ┊     <std::ffi::c_str::NulError as core::fmt::Debug>::fmt::hd213df2c4c15ea9b
+                  0 ┊          0.00% ┊   110 ┊  0.19% ┊ core::option::expect_failed
+                    ┊                ┊   110 ┊  0.19% ┊     core::option::expect_failed::ha1e19f3be1783d86
+                  0 ┊          0.00% ┊   109 ┊  0.19% ┊ <alloc::raw_vec::RawVec<T, A>>::reserve_exact
+                    ┊                ┊   109 ┊  0.19% ┊     <alloc::raw_vec::RawVec<T, A>>::reserve_exact::h90209384f3b9be08
+                  0 ┊          0.00% ┊   103 ┊  0.18% ┊ core::panicking::panic
+                    ┊                ┊   103 ┊  0.18% ┊     core::panicking::panic::hd6b1565e097d11be
+                  0 ┊          0.00% ┊    96 ┊  0.16% ┊ <alloc::arc::Arc<T>>::drop_slow
+                    ┊                ┊    96 ┊  0.16% ┊     <alloc::arc::Arc<T>>::drop_slow::hab85f37fa5d78c06
+                  0 ┊          0.00% ┊    96 ┊  0.16% ┊ <std::error::<impl core::convert::From<alloc::string::String> for alloc::boxed::Box<std::error::Error + core::marker::Sync + core::marker::Send + 'static>>::from::StringError as core::fmt::Debug>::fmt
+                    ┊                ┊    96 ┊  0.16% ┊     <std::error::<impl core::convert::From<alloc::string::String> for alloc::boxed::Box<std::error::Error + core::marker::Sync + core::marker::Send + 'static>>::from::StringError as core::fmt::Debug>::fmt::hf81d6ec3ed3cf437
+                  0 ┊          0.00% ┊    87 ┊  0.15% ┊ std::io::impls::<impl std::io::Write for &'a mut W>::write_fmt
+                    ┊                ┊    87 ┊  0.15% ┊     std::io::impls::<impl std::io::Write for &'a mut W>::write_fmt::hdc863fd6486416b4
+                  0 ┊          0.00% ┊    76 ┊  0.13% ┊ <alloc::string::String as core::convert::From<&'a str>>::from
+                    ┊                ┊    76 ┊  0.13% ┊     <alloc::string::String as core::convert::From<&'a str>>::from::h71d62dd67534ae67
+                  0 ┊          0.00% ┊    73 ┊  0.13% ┊ <alloc::vec::Vec<T>>::remove
+                    ┊                ┊    73 ┊  0.13% ┊     <alloc::vec::Vec<T>>::remove::hba13f8aae5697111
+                  0 ┊          0.00% ┊    62 ┊  0.11% ┊ core::panicking::panic_fmt
+                    ┊                ┊    62 ┊  0.11% ┊     core::panicking::panic_fmt::h2ddf6ebf35664a22
+                  0 ┊          0.00% ┊    61 ┊  0.10% ┊ <core::alloc::CollectionAllocErr as core::fmt::Debug>::fmt
+                    ┊                ┊    61 ┊  0.10% ┊     <core::alloc::CollectionAllocErr as core::fmt::Debug>::fmt::h1e612cc5b402d018
+                  0 ┊          0.00% ┊    44 ┊  0.08% ┊ std::panicking::begin_panic
+                    ┊                ┊    44 ┊  0.08% ┊     std::panicking::begin_panic::h1c67cf480c82ca41
+                  0 ┊          0.00% ┊    42 ┊  0.07% ┊ <alloc::vec::Vec<T> as core::ops::index::Index<I>>::index
+                    ┊                ┊    42 ┊  0.07% ┊     <alloc::vec::Vec<T> as core::ops::index::Index<I>>::index::h0e2d043e9c4be2a4
+                  0 ┊          0.00% ┊    42 ┊  0.07% ┊ <alloc::vec::Vec<T> as core::ops::index::IndexMut<I>>::index_mut
+                    ┊                ┊    42 ┊  0.07% ┊     <alloc::vec::Vec<T> as core::ops::index::IndexMut<I>>::index_mut::he65e880dfe71ede7
+                  0 ┊          0.00% ┊    39 ┊  0.07% ┊ core::str::traits::<impl core::slice::SliceIndex<str> for core::ops::range::Range<usize>>::index::{{closure}}
+                    ┊                ┊    39 ┊  0.07% ┊     core::str::traits::<impl core::slice::SliceIndex<str> for core::ops::range::Range<usize>>::index::{{closure}}::h60168465cb72d0d1.1520
+                  0 ┊          0.00% ┊    31 ┊  0.05% ┊ <core::result::Result<T, E>>::unwrap
+                    ┊                ┊    31 ┊  0.05% ┊     <core::result::Result<T, E>>::unwrap::h6cc6e55b8a35b2a0
+                  0 ┊          0.00% ┊    27 ┊  0.05% ┊ <core::cell::BorrowError as core::fmt::Debug>::fmt
+                    ┊                ┊    27 ┊  0.05% ┊     <core::cell::BorrowError as core::fmt::Debug>::fmt::hf74aff9660f52336
+                  0 ┊          0.00% ┊    27 ┊  0.05% ┊ <core::cell::BorrowMutError as core::fmt::Debug>::fmt
+                    ┊                ┊    27 ┊  0.05% ┊     <core::cell::BorrowMutError as core::fmt::Debug>::fmt::h7d6c4aa36e2bbb3a
+                  0 ┊          0.00% ┊    27 ┊  0.05% ┊ <std::thread::local::AccessError as core::fmt::Debug>::fmt
+                    ┊                ┊    27 ┊  0.05% ┊     <std::thread::local::AccessError as core::fmt::Debug>::fmt::h468179781fdd317a
+                  0 ┊          0.00% ┊    26 ┊  0.04% ┊ <core::result::Result<T, E>>::expect
+                    ┊                ┊    26 ┊  0.04% ┊     <core::result::Result<T, E>>::expect::h43eea250881e7715
+                  0 ┊          0.00% ┊    23 ┊  0.04% ┊ <std::error::<impl core::convert::From<alloc::string::String> for alloc::boxed::Box<std::error::Error + core::marker::Sync + core::marker::Send + 'static>>::from::StringError as std::error::Error>::description
+                    ┊                ┊    23 ┊  0.04% ┊     <std::error::<impl core::convert::From<alloc::string::String> for alloc::boxed::Box<std::error::Error + core::marker::Sync + core::marker::Send + 'static>>::from::StringError as std::error::Error>::description::h81f56e02f5e7f796
+                  0 ┊          0.00% ┊    19 ┊  0.03% ┊ <core::option::Option<T>>::expect
+                    ┊                ┊    19 ┊  0.03% ┊     <core::option::Option<T>>::expect::h53ba5982e622ab98
+                  0 ┊          0.00% ┊    17 ┊  0.03% ┊ <std::error::<impl core::convert::From<alloc::string::String> for alloc::boxed::Box<std::error::Error + core::marker::Sync + core::marker::Send + 'static>>::from::StringError as core::fmt::Display>::fmt
+                    ┊                ┊    17 ┊  0.03% ┊     <std::error::<impl core::convert::From<alloc::string::String> for alloc::boxed::Box<std::error::Error + core::marker::Sync + core::marker::Send + 'static>>::from::StringError as core::fmt::Display>::fmt::h289d4f072dbab567
+                  0 ┊          0.00% ┊    17 ┊  0.03% ┊ std::io::impls::<impl std::io::Write for &'a mut W>::write
+                    ┊                ┊    17 ┊  0.03% ┊     std::io::impls::<impl std::io::Write for &'a mut W>::write::hb0915e9baef1a41b
+                  0 ┊          0.00% ┊    14 ┊  0.02% ┊ std::error::Error::type_id
+                    ┊                ┊    14 ┊  0.02% ┊     std::error::Error::type_id::hc259f20f01bc805f
+                  0 ┊          0.00% ┊    10 ┊  0.02% ┊ std::error::Error::cause
+                    ┊                ┊    10 ┊  0.02% ┊     std::error::Error::cause::h4980985f30856d32
+                  0 ┊          0.00% ┊    10 ┊  0.02% ┊ std::io::impls::<impl std::io::Write for &'a mut W>::flush
+                    ┊                ┊    10 ┊  0.02% ┊     std::io::impls::<impl std::io::Write for &'a mut W>::flush::h19ff0277e6b3d742
+                  0 ┊          0.00% ┊    10 ┊  0.02% ┊ std::io::impls::<impl std::io::Write for &'a mut W>::write_all
+                    ┊                ┊    10 ┊  0.02% ┊     std::io::impls::<impl std::io::Write for &'a mut W>::write_all::hcfa3a97487c6f2fb
+                  0 ┊          0.00% ┊     9 ┊  0.02% ┊ core::fmt::ArgumentV1::show_usize
+                    ┊                ┊     9 ┊  0.02% ┊     core::fmt::ArgumentV1::show_usize::hfae8c3232f8e141e
+                  0 ┊          0.00% ┊     5 ┊  0.01% ┊ <monos::One as monos::Code>::code
+                    ┊                ┊     5 ┊  0.01% ┊     <monos::One as monos::Code>::code::h94feb5b1732d1e4b
+                  0 ┊          0.00% ┊     5 ┊  0.01% ┊ <monos::Two as monos::Code>::code
+                    ┊                ┊     5 ┊  0.01% ┊     <monos::Two as monos::Code>::code::h394b28ea75b29629
+                  0 ┊          0.00% ┊     5 ┊  0.01% ┊ <monos::Zero as monos::Code>::code
+                    ┊                ┊     5 ┊  0.01% ┊     <monos::Zero as monos::Code>::code::h86bfbb5b849aa69f
+                  0 ┊          0.00% ┊     5 ┊  0.01% ┊ <std::io::Write::write_fmt::Adaptor<'a, T> as core::fmt::Write>::write_str
+                    ┊                ┊     5 ┊  0.01% ┊     <std::io::Write::write_fmt::Adaptor<'a, T> as core::fmt::Write>::write_str::h1fcd48dcfdd79843
+               6459 ┊         11.10% ┊ 34980 ┊ 60.10% ┊ Σ [235 Total Rows]

--- a/twiggy/tests/expectations/monos_all_monos
+++ b/twiggy/tests/expectations/monos_all_monos
@@ -1,0 +1,52 @@
+ Apprx. Bloat Bytes │ Apprx. Bloat % │ Bytes │ %      │ Monomorphizations
+────────────────────┼────────────────┼───────┼────────┼────────────────────────────────────────────────────────────────────────────────────────────────────
+               1977 ┊          3.40% ┊  3003 ┊  5.16% ┊ alloc::slice::merge_sort
+                    ┊                ┊  1026 ┊  1.76% ┊     alloc::slice::merge_sort::hb3d195f9800bdad6
+                    ┊                ┊  1026 ┊  1.76% ┊     alloc::slice::merge_sort::hfcf2318d7dc71d03
+                    ┊                ┊   951 ┊  1.63% ┊     alloc::slice::merge_sort::hcfca67f5c75a52ef
+               1302 ┊          2.24% ┊  3996 ┊  6.87% ┊ <&'a T as core::fmt::Debug>::fmt
+                    ┊                ┊  2694 ┊  4.63% ┊     <&'a T as core::fmt::Debug>::fmt::h1c27955d8de3ff17
+                    ┊                ┊   568 ┊  0.98% ┊     <&'a T as core::fmt::Debug>::fmt::hea6a77c4dcddb7ac
+                    ┊                ┊   433 ┊  0.74% ┊     <&'a T as core::fmt::Debug>::fmt::hfbacf6f5c9f53bb2
+                    ┊                ┊   301 ┊  0.52% ┊     <&'a T as core::fmt::Debug>::fmt::h199e8e1c5752e6f1
+                973 ┊          1.67% ┊  1118 ┊  1.92% ┊ core::result::unwrap_failed
+                    ┊                ┊   145 ┊  0.25% ┊     core::result::unwrap_failed::h137aa4f433aba1a9
+                    ┊                ┊   145 ┊  0.25% ┊     core::result::unwrap_failed::h4cc73eb9bf19ce32
+                    ┊                ┊   145 ┊  0.25% ┊     core::result::unwrap_failed::h9bd27c3a9ad7c001
+                    ┊                ┊   138 ┊  0.24% ┊     core::result::unwrap_failed::h9a7678774db14d67
+                    ┊                ┊   138 ┊  0.24% ┊     core::result::unwrap_failed::ha3e58cfc7f422ab4
+                    ┊                ┊   138 ┊  0.24% ┊     core::result::unwrap_failed::ha7651fcaac40f701
+                    ┊                ┊   138 ┊  0.24% ┊     core::result::unwrap_failed::hcb258ce32bda3d85
+                    ┊                ┊   131 ┊  0.23% ┊     core::result::unwrap_failed::hcfddf900474e698a
+                558 ┊          0.96% ┊   714 ┊  1.23% ┊ <alloc::raw_vec::RawVec<T, A>>::double
+                    ┊                ┊   156 ┊  0.27% ┊     <alloc::raw_vec::RawVec<T, A>>::double::h28f86621ee2a10aa
+                    ┊                ┊   156 ┊  0.27% ┊     <alloc::raw_vec::RawVec<T, A>>::double::h956450b93bdc9e1e
+                    ┊                ┊   156 ┊  0.27% ┊     <alloc::raw_vec::RawVec<T, A>>::double::hcb2fb5861b96a3b0
+                    ┊                ┊   147 ┊  0.25% ┊     <alloc::raw_vec::RawVec<T, A>>::double::ha715b4e5cc3c60ae
+                    ┊                ┊    99 ┊  0.17% ┊     <alloc::raw_vec::RawVec<T, A>>::double::h77ff8547127c5db2
+                512 ┊          0.88% ┊   798 ┊  1.37% ┊ std::thread::local::os::destroy_value
+                    ┊                ┊   286 ┊  0.49% ┊     std::thread::local::os::destroy_value::hca8124786bee4a79
+                    ┊                ┊   281 ┊  0.48% ┊     std::thread::local::os::destroy_value::h094cf4f2a025ba2b
+                    ┊                ┊   231 ┊  0.40% ┊     std::thread::local::os::destroy_value::h453d41f6c315da32
+                234 ┊          0.40% ┊   354 ┊  0.61% ┊ alloc::slice::insert_head
+                    ┊                ┊   120 ┊  0.21% ┊     alloc::slice::insert_head::h2cdb84a455761146
+                    ┊                ┊   120 ┊  0.21% ┊     alloc::slice::insert_head::haf6e08236bab8bde
+                    ┊                ┊   114 ┊  0.20% ┊     alloc::slice::insert_head::hed0e79da03eeec8b
+                196 ┊          0.34% ┊   294 ┊  0.51% ┊ <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_fmt
+                    ┊                ┊    98 ┊  0.17% ┊     <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_fmt::h1b74a5fafe15c8eb
+                    ┊                ┊    98 ┊  0.17% ┊     <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_fmt::h24034d1c07bfae93
+                    ┊                ┊    98 ┊  0.17% ┊     <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_fmt::h5ebed3e159974658
+                195 ┊          0.34% ┊   270 ┊  0.46% ┊ <alloc::vec::Vec<T>>::push
+                    ┊                ┊    75 ┊  0.13% ┊     <alloc::vec::Vec<T>>::push::h98b02eda22d1ca25
+                    ┊                ┊    66 ┊  0.11% ┊     <alloc::vec::Vec<T>>::push::h5729b9e7651ef67b
+                    ┊                ┊    66 ┊  0.11% ┊     <alloc::vec::Vec<T>>::push::hc927b4bedb35b00d
+                    ┊                ┊    63 ┊  0.11% ┊     <alloc::vec::Vec<T>>::push::h9415ef699ccc65d8
+                119 ┊          0.20% ┊   180 ┊  0.31% ┊ <core::ops::range::Range<usize> as core::slice::SliceIndex<[T]>>::index_mut
+                    ┊                ┊    61 ┊  0.10% ┊     <core::ops::range::Range<usize> as core::slice::SliceIndex<[T]>>::index_mut::hba42cce6d0c0099b
+                    ┊                ┊    61 ┊  0.10% ┊     <core::ops::range::Range<usize> as core::slice::SliceIndex<[T]>>::index_mut::hbf8fcfe76c1f6657
+                    ┊                ┊    58 ┊  0.10% ┊     <core::ops::range::Range<usize> as core::slice::SliceIndex<[T]>>::index_mut::h1c053f01b6f95d93
+                 95 ┊          0.16% ┊   190 ┊  0.33% ┊ core::fmt::Write::write_fmt
+                    ┊                ┊    95 ┊  0.16% ┊     core::fmt::Write::write_fmt::ha5ae3249cacba520
+                    ┊                ┊    95 ┊  0.16% ┊     core::fmt::Write::write_fmt::hef4632e1398f5ac8
+                298 ┊          0.51% ┊ 24063 ┊ 41.34% ┊ ... and 189 more.
+               6459 ┊         11.10% ┊ 34980 ┊ 60.10% ┊ Σ [237 Total Rows]

--- a/twiggy/tests/expectations/monos_only_all_generics
+++ b/twiggy/tests/expectations/monos_only_all_generics
@@ -1,0 +1,94 @@
+ Apprx. Bloat Bytes │ Apprx. Bloat % │ Bytes │ %      │ Monomorphizations
+────────────────────┼────────────────┼───────┼────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+               1977 ┊          3.40% ┊  3003 ┊  5.16% ┊ alloc::slice::merge_sort
+               1302 ┊          2.24% ┊  3996 ┊  6.87% ┊ <&'a T as core::fmt::Debug>::fmt
+                973 ┊          1.67% ┊  1118 ┊  1.92% ┊ core::result::unwrap_failed
+                558 ┊          0.96% ┊   714 ┊  1.23% ┊ <alloc::raw_vec::RawVec<T, A>>::double
+                512 ┊          0.88% ┊   798 ┊  1.37% ┊ std::thread::local::os::destroy_value
+                234 ┊          0.40% ┊   354 ┊  0.61% ┊ alloc::slice::insert_head
+                196 ┊          0.34% ┊   294 ┊  0.51% ┊ <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_fmt
+                195 ┊          0.34% ┊   270 ┊  0.46% ┊ <alloc::vec::Vec<T>>::push
+                119 ┊          0.20% ┊   180 ┊  0.31% ┊ <core::ops::range::Range<usize> as core::slice::SliceIndex<[T]>>::index_mut
+                 95 ┊          0.16% ┊   190 ┊  0.33% ┊ core::fmt::Write::write_fmt
+                 90 ┊          0.15% ┊   167 ┊  0.29% ┊ core::ptr::drop_in_place
+                 51 ┊          0.09% ┊    68 ┊  0.12% ┊ <&'a T as core::fmt::Display>::fmt
+                 39 ┊          0.07% ┊    78 ┊  0.13% ┊ core::str::traits::<impl core::slice::SliceIndex<str> for core::ops::range::RangeFrom<usize>>::index::{{closure}}
+                 30 ┊          0.05% ┊    45 ┊  0.08% ┊ <alloc::raw_vec::RawVec<T, A> as core::ops::drop::Drop>::drop
+                 20 ┊          0.03% ┊    40 ┊  0.07% ┊ core::str::traits::<impl core::slice::SliceIndex<str> for core::ops::range::RangeTo<usize>>::index::{{closure}}
+                 19 ┊          0.03% ┊    73 ┊  0.13% ┊ <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_str
+                 17 ┊          0.03% ┊   367 ┊  0.63% ┊ <core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_char
+                 14 ┊          0.02% ┊    21 ┊  0.04% ┊ monos::generic
+                 13 ┊          0.02% ┊    26 ┊  0.04% ┊ <T as core::any::Any>::get_type_id
+                  5 ┊          0.01% ┊   256 ┊  0.44% ┊ core::fmt::Write::write_char
+                  0 ┊          0.00% ┊  3350 ┊  5.76% ┊ dlmalloc::dlmalloc::Dlmalloc::malloc
+                  0 ┊          0.00% ┊  1633 ┊  2.81% ┊ core::fmt::Formatter::pad
+                  0 ┊          0.00% ┊  1483 ┊  2.55% ┊ std::panicking::rust_panic_with_hook
+                  0 ┊          0.00% ┊  1241 ┊  2.13% ┊ core::fmt::Formatter::pad_integral
+                  0 ┊          0.00% ┊  1187 ┊  2.04% ┊ core::str::slice_error_fail
+                  0 ┊          0.00% ┊  1113 ┊  1.91% ┊ core::fmt::write
+                  0 ┊          0.00% ┊   902 ┊  1.55% ┊ <char as core::fmt::Debug>::fmt
+                  0 ┊          0.00% ┊   897 ┊  1.54% ┊ dlmalloc::dlmalloc::Dlmalloc::free
+                  0 ┊          0.00% ┊   728 ┊  1.25% ┊ core::slice::memchr::memchr
+                  0 ┊          0.00% ┊   702 ┊  1.21% ┊ <core::fmt::builders::PadAdapter<'a> as core::fmt::Write>::write_str
+                  0 ┊          0.00% ┊   657 ┊  1.13% ┊ std::panicking::default_hook::{{closure}}
+                  0 ┊          0.00% ┊   638 ┊  1.10% ┊ dlmalloc::dlmalloc::Dlmalloc::dispose_chunk
+                  0 ┊          0.00% ┊   513 ┊  0.88% ┊ std::thread::Thread::new
+                  0 ┊          0.00% ┊   473 ┊  0.81% ┊ <core::alloc::LayoutErr as core::fmt::Debug>::fmt
+                  0 ┊          0.00% ┊   384 ┊  0.66% ┊ std::io::Write::write_fmt
+                  0 ┊          0.00% ┊   366 ┊  0.63% ┊ dlmalloc::dlmalloc::Dlmalloc::memalign
+                  0 ┊          0.00% ┊   358 ┊  0.62% ┊ core::fmt::Formatter::pad_integral::{{closure}}
+                  0 ┊          0.00% ┊   350 ┊  0.60% ┊ core::unicode::printable::check
+                  0 ┊          0.00% ┊   346 ┊  0.59% ┊ core::fmt::builders::DebugTuple::field
+                  0 ┊          0.00% ┊   332 ┊  0.57% ┊ dlmalloc::dlmalloc::Dlmalloc::insert_large_chunk
+                  0 ┊          0.00% ┊   311 ┊  0.53% ┊ core::fmt::num::<impl core::fmt::Display for u32>::fmt
+                  0 ┊          0.00% ┊   311 ┊  0.53% ┊ core::fmt::num::<impl core::fmt::Display for usize>::fmt
+                  0 ┊          0.00% ┊   309 ┊  0.53% ┊ dlmalloc::dlmalloc::Dlmalloc::unlink_large_chunk
+                  0 ┊          0.00% ┊   294 ┊  0.51% ┊ core::fmt::num::<impl core::fmt::Debug for usize>::fmt
+                  0 ┊          0.00% ┊   288 ┊  0.49% ┊ <std::thread::local::os::Key<T>>::get
+                  0 ┊          0.00% ┊   288 ┊  0.49% ┊ std::panicking::LOCAL_STDERR::__getit
+                  0 ┊          0.00% ┊   288 ┊  0.49% ┊ std::sys_common::thread_info::THREAD_INFO::__getit
+                  0 ┊          0.00% ┊   218 ┊  0.37% ┊ alloc::slice::merge_sort::collapse
+                  0 ┊          0.00% ┊   187 ┊  0.32% ┊ core::fmt::builders::DebugTuple::finish
+                  0 ┊          0.00% ┊   173 ┊  0.30% ┊ std::panicking::begin_panic_fmt
+                  0 ┊          0.00% ┊   168 ┊  0.29% ┊ core::unicode::printable::is_printable
+                  0 ┊          0.00% ┊   158 ┊  0.27% ┊ std::sys_common::util::dumb_print
+                  0 ┊          0.00% ┊   154 ┊  0.26% ┊ core::alloc::Layout::repeat
+                  0 ┊          0.00% ┊   147 ┊  0.25% ┊ <core::ops::range::Range<Idx> as core::fmt::Debug>::fmt
+                  0 ┊          0.00% ┊   133 ┊  0.23% ┊ core::slice::slice_index_len_fail
+                  0 ┊          0.00% ┊   133 ┊  0.23% ┊ core::slice::slice_index_order_fail
+                  0 ┊          0.00% ┊   132 ┊  0.23% ┊ core::panicking::panic_bounds_check
+                  0 ┊          0.00% ┊   130 ┊  0.22% ┊ <alloc::raw_vec::RawVec<T, A>>::reserve
+                  0 ┊          0.00% ┊   120 ┊  0.21% ┊ <std::ffi::c_str::NulError as core::fmt::Debug>::fmt
+                  0 ┊          0.00% ┊   110 ┊  0.19% ┊ core::option::expect_failed
+                  0 ┊          0.00% ┊   109 ┊  0.19% ┊ <alloc::raw_vec::RawVec<T, A>>::reserve_exact
+                  0 ┊          0.00% ┊   103 ┊  0.18% ┊ core::panicking::panic
+                  0 ┊          0.00% ┊    96 ┊  0.16% ┊ <alloc::arc::Arc<T>>::drop_slow
+                  0 ┊          0.00% ┊    96 ┊  0.16% ┊ <std::error::<impl core::convert::From<alloc::string::String> for alloc::boxed::Box<std::error::Error + core::marker::Sync + core::marker::Send + 'static>>::from::StringError as core::fmt::Debug>::fmt
+                  0 ┊          0.00% ┊    87 ┊  0.15% ┊ std::io::impls::<impl std::io::Write for &'a mut W>::write_fmt
+                  0 ┊          0.00% ┊    76 ┊  0.13% ┊ <alloc::string::String as core::convert::From<&'a str>>::from
+                  0 ┊          0.00% ┊    73 ┊  0.13% ┊ <alloc::vec::Vec<T>>::remove
+                  0 ┊          0.00% ┊    62 ┊  0.11% ┊ core::panicking::panic_fmt
+                  0 ┊          0.00% ┊    61 ┊  0.10% ┊ <core::alloc::CollectionAllocErr as core::fmt::Debug>::fmt
+                  0 ┊          0.00% ┊    44 ┊  0.08% ┊ std::panicking::begin_panic
+                  0 ┊          0.00% ┊    42 ┊  0.07% ┊ <alloc::vec::Vec<T> as core::ops::index::Index<I>>::index
+                  0 ┊          0.00% ┊    42 ┊  0.07% ┊ <alloc::vec::Vec<T> as core::ops::index::IndexMut<I>>::index_mut
+                  0 ┊          0.00% ┊    39 ┊  0.07% ┊ core::str::traits::<impl core::slice::SliceIndex<str> for core::ops::range::Range<usize>>::index::{{closure}}
+                  0 ┊          0.00% ┊    31 ┊  0.05% ┊ <core::result::Result<T, E>>::unwrap
+                  0 ┊          0.00% ┊    27 ┊  0.05% ┊ <core::cell::BorrowError as core::fmt::Debug>::fmt
+                  0 ┊          0.00% ┊    27 ┊  0.05% ┊ <core::cell::BorrowMutError as core::fmt::Debug>::fmt
+                  0 ┊          0.00% ┊    27 ┊  0.05% ┊ <std::thread::local::AccessError as core::fmt::Debug>::fmt
+                  0 ┊          0.00% ┊    26 ┊  0.04% ┊ <core::result::Result<T, E>>::expect
+                  0 ┊          0.00% ┊    23 ┊  0.04% ┊ <std::error::<impl core::convert::From<alloc::string::String> for alloc::boxed::Box<std::error::Error + core::marker::Sync + core::marker::Send + 'static>>::from::StringError as std::error::Error>::description
+                  0 ┊          0.00% ┊    19 ┊  0.03% ┊ <core::option::Option<T>>::expect
+                  0 ┊          0.00% ┊    17 ┊  0.03% ┊ <std::error::<impl core::convert::From<alloc::string::String> for alloc::boxed::Box<std::error::Error + core::marker::Sync + core::marker::Send + 'static>>::from::StringError as core::fmt::Display>::fmt
+                  0 ┊          0.00% ┊    17 ┊  0.03% ┊ std::io::impls::<impl std::io::Write for &'a mut W>::write
+                  0 ┊          0.00% ┊    14 ┊  0.02% ┊ std::error::Error::type_id
+                  0 ┊          0.00% ┊    10 ┊  0.02% ┊ std::error::Error::cause
+                  0 ┊          0.00% ┊    10 ┊  0.02% ┊ std::io::impls::<impl std::io::Write for &'a mut W>::flush
+                  0 ┊          0.00% ┊    10 ┊  0.02% ┊ std::io::impls::<impl std::io::Write for &'a mut W>::write_all
+                  0 ┊          0.00% ┊     9 ┊  0.02% ┊ core::fmt::ArgumentV1::show_usize
+                  0 ┊          0.00% ┊     5 ┊  0.01% ┊ <monos::One as monos::Code>::code
+                  0 ┊          0.00% ┊     5 ┊  0.01% ┊ <monos::Two as monos::Code>::code
+                  0 ┊          0.00% ┊     5 ┊  0.01% ┊ <monos::Zero as monos::Code>::code
+                  0 ┊          0.00% ┊     5 ┊  0.01% ┊ <std::io::Write::write_fmt::Adaptor<'a, T> as core::fmt::Write>::write_str
+               6459 ┊         11.10% ┊ 34980 ┊ 60.10% ┊ Σ [91 Total Rows]

--- a/twiggy/tests/tests.rs
+++ b/twiggy/tests/tests.rs
@@ -347,6 +347,30 @@ test!(
     "csv"
 );
 
+test!(monos_all, "monos", "./fixtures/monos.wasm", "-a");
+
+test!(
+    monos_only_all_generics,
+    "monos",
+    "./fixtures/monos.wasm",
+    "-g",
+    "-a"
+);
+
+test!(
+    monos_all_generics,
+    "monos",
+    "./fixtures/monos.wasm",
+    "--all-generics"
+);
+
+test!(
+    monos_all_monos,
+    "monos",
+    "./fixtures/monos.wasm",
+    "--all-monos"
+);
+
 test!(
     diff_wee_alloc,
     "diff",


### PR DESCRIPTION
After #118 the second PR for #109 

This time for the `monos` command, and with even three new flags :D to cover the 2-dimensional output of generics and their individual monomorphizations:

```
-a, --all
    --all-generics
    --all-monos
```

Only some more tests are needed to get it out of `WIP`... I'll hurry up ;)