### PR TITLE
Remove stabilized wasm feature attributes

### DIFF
--- a/opt/opt.rs
+++ b/opt/opt.rs
@@ -3,7 +3,7 @@
 #![deny(missing_debug_implementations)]
 #![cfg_attr(
     feature = "wasm",
-    feature(use_extern_macros, wasm_custom_section, wasm_import_module)
+    feature(use_extern_macros)
 )]
 
 #[macro_use]

--- a/wasm-api/wasm-api.rs
+++ b/wasm-api/wasm-api.rs
@@ -1,6 +1,6 @@
 #![cfg(target_arch = "wasm32")]
 #![cfg(feature = "emit_json")]
-#![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+#![feature(use_extern_macros)]
 
 extern crate wasm_bindgen;
 


### PR DESCRIPTION
According to https://github.com/rustwasm/book/pull/52 `wasm_custom_section` and `wasm_import_module` are stabilized, and not supported anymore by latest nightly `rustc`

Keeping them results in...

```console
> cargo build
...
error[E0635]: unknown feature `wasm_import_module`
...
error[E0635]: unknown feature `wasm_custom_section`
...
```

... and makes currently all TravisCI `JOB="wasm"` builds fail, like https://travis-ci.org/rustwasm/twiggy/jobs/415881546 