### PR TITLE
ci: grab the wasm-bindgen version from Cargo.toml

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -2,39 +2,53 @@
 
 set -eux
 
-cd "$(dirname "$0")/.."
+ROOT="$(dirname "$0")/.."
+cd "$ROOT"
 
-case "$JOB" in
-    "test")
-        cargo test --all --exclude twiggy-wasm-api
-        ;;
+function main {
+    case "$JOB" in
+        "test")
+            cargo test --all --exclude twiggy-wasm-api
+            ;;
 
-    "wasm")
-        rustup update nightly
-        rustup target add wasm32-unknown-unknown --toolchain nightly
+        "wasm")
+            rustup update nightly
+            rustup target add wasm32-unknown-unknown --toolchain nightly
 
-        cd ./wasm-api
-        cargo +nightly build --release --target wasm32-unknown-unknown
+            cd ./wasm-api
+            cargo +nightly build --release --target wasm32-unknown-unknown
 
-        # Install wasm-bindgen at the correct version, if necessary.
-        test -x ./bin/wasm-bindgen \
-            && test "$(./bin/wasm-bindgen --version | xargs)" == "wasm-bindgen 0.2.12" \
-                || cargo +nightly install -f wasm-bindgen-cli --version 0.2.12 --root "$(pwd)"
+            # Install wasm-bindgen at the correct version, if necessary.
+            local version="$(get_wasm_bindgen_version)"
+            test -x ./bin/wasm-bindgen \
+                && test "$(./bin/wasm-bindgen --version | xargs)" == "wasm-bindgen $version" \
+                    || cargo +nightly install -f wasm-bindgen-cli --version "$version" --root "$(pwd)"
 
-        ./bin/wasm-bindgen --out-dir . ../target/wasm32-unknown-unknown/release/twiggy_wasm_api.wasm
+            ./bin/wasm-bindgen --out-dir . ../target/wasm32-unknown-unknown/release/twiggy_wasm_api.wasm
 
-        if [[ $(which wasm-opt) != "" ]]; then
-            temp=$(mktemp "twiggy-XXXXXX.wasm")
-            cp twiggy_wasm_api_bg.wasm "$temp"
-            wasm-opt -Oz -g "$temp" -o twiggy_wasm_api_bg.wasm
-        fi
+            if [[ $(which wasm-opt) != "" ]]; then
+                local temp=$(mktemp "twiggy-XXXXXX.wasm")
+                cp twiggy_wasm_api_bg.wasm "$temp"
+                wasm-opt -Oz -g "$temp" -o twiggy_wasm_api_bg.wasm
+                rm "$temp"
+            fi
 
-        wc -c twiggy_wasm_api_bg.wasm
-        ;;
+            wc -c twiggy_wasm_api_bg.wasm
+            ;;
 
-    *)
-        echo "Error: unknown \$JOB = $JOB"
-        exit 1
-        ;;
+        *)
+            echo "Error: unknown \$JOB = $JOB"
+            exit 1
+            ;;
+    esac
+}
 
-esac
+function get_wasm_bindgen_version {
+    grep wasm-bindgen -A 1 Cargo.toml \
+        | grep version \
+        | cut -f2 -d '=' \
+        | tr '"' ' ' \
+        | xargs
+}
+
+main


### PR DESCRIPTION
This way, when we update wasm-bindgen versions, the script doesn't need to also be updated. This will unbreak dependabot for wasm-bindgen updates.