### PR TITLE
Added regular expressions and specific arguments to diff.

### DIFF
--- a/opt/definitions.rs
+++ b/opt/definitions.rs
@@ -455,9 +455,16 @@ pub struct Diff {
     #[structopt(short = "f", long = "format", default_value = "text")]
     output_format: traits::OutputFormat,
 
+    /// The name of the item(s) whose diff should be printed.
+    items: Vec<String>,
+
     /// The maximum number of items to display.
     #[structopt(short = "n", default_value = "20")]
     max_items: u32,
+
+    /// Whether or not `items` should be treated as regular expressions.
+    #[structopt(long = "regex")]
+    using_regexps: bool,
 }
 
 impl Default for Diff {
@@ -472,8 +479,20 @@ impl Default for Diff {
             #[cfg(feature = "cli")]
             output_format: Default::default(),
 
+            items: Default::default(),
             max_items: 20,
+            using_regexps: false,
         }
+    }
+}
+
+impl Diff {
+    // TODO: wasm-bindgen does not support sending Vec<String> across
+    // the wasm ABI boundary yet.
+
+    /// The items whose dominators subtree should be printed.
+    pub fn items(&self) -> &[String] {
+        &self.items
     }
 }
 
@@ -484,9 +503,19 @@ impl Diff {
         self.max_items
     }
 
+    /// Whether or not `items` should be treated as regular expressions.
+    pub fn using_regexps(&self) -> bool {
+        self.using_regexps
+    }
+
     /// Set the maximum number of items to display.
     pub fn set_max_items(&mut self, n: u32) {
         self.max_items = n;
+    }
+
+    /// Set whether or not `items` should be treated as regular expressions.
+    pub fn set_using_regexps(&mut self, using_regexps: bool) {
+        self.using_regexps = using_regexps;
     }
 }
 

--- a/twiggy/tests/expectations/diff_test_exact_wee_alloc
+++ b/twiggy/tests/expectations/diff_test_exact_wee_alloc
@@ -1,0 +1,5 @@
+ Delta Bytes │ Item
+─────────────┼──────────────────
+        +243 ┊ goodbye
+         +15 ┊ hello
+        +258 ┊ Σ [2 Total Rows]

--- a/twiggy/tests/expectations/diff_test_regex_wee_alloc
+++ b/twiggy/tests/expectations/diff_test_regex_wee_alloc
@@ -1,0 +1,11 @@
+ Delta Bytes │ Item
+─────────────┼──────────────────
+       -1034 ┊ data[3]
+         -25 ┊ data[1]
+         -25 ┊ data[2]
+          -8 ┊ type[4]
+          -4 ┊ type[5]
+          +2 ┊ data[0]
+          -2 ┊ type[0]
+          -1 ┊ type[1]
+       -1097 ┊ Σ [8 Total Rows]

--- a/twiggy/tests/tests.rs
+++ b/twiggy/tests/tests.rs
@@ -417,6 +417,24 @@ test!(
     "5"
 );
 
+test!(
+    diff_test_regex_wee_alloc,
+    "diff",
+    "./fixtures/wee_alloc.wasm",
+    "./fixtures/wee_alloc.2.wasm",
+    "--regex",
+    "(data|type)\\[\\d*\\]"
+);
+
+test!(
+    diff_test_exact_wee_alloc,
+    "diff",
+    "./fixtures/wee_alloc.wasm",
+    "./fixtures/wee_alloc.2.wasm",
+    "hello",
+    "goodbye"
+);
+
 test!(garbage, "garbage", "./fixtures/garbage.wasm");
 
 test!(


### PR DESCRIPTION
This commit adds the ability to specify items to check the diffs off, both using regular expressions and exact names. Additionally, fixed a minor issue where a "remaining" row would be shown in the output if there were 0 rows remaining.