### PR TITLE
 Allow to select mode of parsing of the input data. 

### DIFF
--- a/opt/definitions.rs
+++ b/opt/definitions.rs
@@ -52,6 +52,11 @@ pub struct Top {
     #[structopt(parse(from_os_str))]
     input: path::PathBuf,
 
+    /// The parse mode for the input binary data.
+    #[cfg(feature = "cli")]
+    #[structopt(long = "mode", default_value = "auto")]
+    parse_mode: traits::ParseMode,
+
     /// The destination to write the output to. Defaults to `stdout`.
     #[cfg(feature = "cli")]
     #[structopt(short = "o", default_value = "-")]
@@ -80,6 +85,8 @@ impl Default for Top {
         Top {
             #[cfg(feature = "cli")]
             input: Default::default(),
+            #[cfg(feature = "cli")]
+            parse_mode: Default::default(),
             #[cfg(feature = "cli")]
             output_destination: Default::default(),
             #[cfg(feature = "cli")]
@@ -139,6 +146,11 @@ pub struct Dominators {
     #[cfg(feature = "cli")]
     #[structopt(parse(from_os_str))]
     input: path::PathBuf,
+
+    /// The parse mode for the input binary data.
+    #[cfg(feature = "cli")]
+    #[structopt(long = "mode", default_value = "auto")]
+    parse_mode: traits::ParseMode,
 
     /// The destination to write the output to. Defaults to `stdout`.
     #[cfg(feature = "cli")]
@@ -225,6 +237,11 @@ pub struct Paths {
     #[structopt(parse(from_os_str))]
     input: path::PathBuf,
 
+    /// The parse mode for the input binary data.
+    #[cfg(feature = "cli")]
+    #[structopt(long = "mode", default_value = "auto")]
+    parse_mode: traits::ParseMode,
+
     /// The destination to write the output to. Defaults to `stdout`.
     #[cfg(feature = "cli")]
     #[structopt(short = "o", default_value = "-")]
@@ -260,6 +277,8 @@ impl Default for Paths {
         Paths {
             #[cfg(feature = "cli")]
             input: Default::default(),
+            #[cfg(feature = "cli")]
+            parse_mode: Default::default(),
             #[cfg(feature = "cli")]
             output_destination: Default::default(),
             #[cfg(feature = "cli")]
@@ -348,6 +367,11 @@ pub struct Monos {
     #[structopt(parse(from_os_str))]
     input: path::PathBuf,
 
+    /// The parse mode for the input binary data.
+    #[cfg(feature = "cli")]
+    #[structopt(short = "d", long = "mode", default_value = "auto")]
+    parse_mode: traits::ParseMode,
+
     /// The destination to write the output to. Defaults to `stdout`.
     #[cfg(feature = "cli")]
     #[structopt(short = "o", default_value = "-")]
@@ -392,6 +416,8 @@ impl Default for Monos {
         Monos {
             #[cfg(feature = "cli")]
             input: Default::default(),
+            #[cfg(feature = "cli")]
+            parse_mode: Default::default(),
             #[cfg(feature = "cli")]
             output_destination: Default::default(),
             #[cfg(feature = "cli")]
@@ -477,6 +503,11 @@ pub struct Diff {
     #[structopt(parse(from_os_str))]
     old_input: path::PathBuf,
 
+    /// The parse mode for the input binary data.
+    #[cfg(feature = "cli")]
+    #[structopt(long = "mode", default_value = "auto")]
+    parse_mode: traits::ParseMode,
+
     /// The path to the new version of the input binary.
     #[cfg(feature = "cli")]
     #[structopt(parse(from_os_str))]
@@ -509,6 +540,8 @@ impl Default for Diff {
         Diff {
             #[cfg(feature = "cli")]
             old_input: Default::default(),
+            #[cfg(feature = "cli")]
+            parse_mode: Default::default(),
             #[cfg(feature = "cli")]
             new_input: Default::default(),
             #[cfg(feature = "cli")]
@@ -567,6 +600,11 @@ pub struct Garbage {
     #[structopt(parse(from_os_str))]
     input: path::PathBuf,
 
+    /// The parse mode for the input binary data.
+    #[cfg(feature = "cli")]
+    #[structopt(long = "mode", default_value = "auto")]
+    parse_mode: traits::ParseMode,
+
     /// The destination to write the output to. Defaults to `stdout`.
     #[cfg(feature = "cli")]
     #[structopt(short = "o", default_value = "-")]
@@ -591,6 +629,8 @@ impl Default for Garbage {
         Garbage {
             #[cfg(feature = "cli")]
             input: Default::default(),
+            #[cfg(feature = "cli")]
+            parse_mode: Default::default(),
             #[cfg(feature = "cli")]
             output_destination: Default::default(),
             #[cfg(feature = "cli")]

--- a/opt/opt.rs
+++ b/opt/opt.rs
@@ -35,6 +35,9 @@ cfg_if! {
             /// Get the input file path.
             fn input(&self) -> &path::Path;
 
+            /// Get the input data parse mode.
+            fn parse_mode(&self) -> traits::ParseMode;
+
             /// Get the output destination.
             fn output_destination(&self) -> &OutputDestination;
 
@@ -51,6 +54,17 @@ cfg_if! {
                     Options::Monos(ref monos) => monos.input(),
                     Options::Diff(ref diff) => diff.input(),
                     Options::Garbage(ref garbo) => garbo.input(),
+                }
+            }
+
+            fn parse_mode(&self) -> traits::ParseMode {
+                match *self {
+                    Options::Top(ref top) => top.parse_mode(),
+                    Options::Dominators(ref doms) => doms.parse_mode(),
+                    Options::Paths(ref paths) => paths.parse_mode(),
+                    Options::Monos(ref monos) => monos.parse_mode(),
+                    Options::Diff(ref diff) => diff.parse_mode(),
+                    Options::Garbage(ref garbo) => garbo.parse_mode(),
                 }
             }
 
@@ -82,6 +96,10 @@ cfg_if! {
                 &self.input
             }
 
+            fn parse_mode(&self) -> traits::ParseMode {
+                self.parse_mode
+            }
+
             fn output_destination(&self) -> &OutputDestination {
                 &self.output_destination
             }
@@ -94,6 +112,10 @@ cfg_if! {
         impl CommonCliOptions for Dominators {
             fn input(&self) -> &path::Path {
                 &self.input
+            }
+
+            fn parse_mode(&self) -> traits::ParseMode {
+                self.parse_mode
             }
 
             fn output_destination(&self) -> &OutputDestination {
@@ -110,6 +132,10 @@ cfg_if! {
                 &self.input
             }
 
+            fn parse_mode(&self) -> traits::ParseMode {
+                self.parse_mode
+            }
+
             fn output_destination(&self) -> &OutputDestination {
                 &self.output_destination
             }
@@ -124,6 +150,10 @@ cfg_if! {
                 &self.input
             }
 
+            fn parse_mode(&self) -> traits::ParseMode {
+                self.parse_mode
+            }
+
             fn output_destination(&self) -> &OutputDestination {
                 &self.output_destination
             }
@@ -136,6 +166,10 @@ cfg_if! {
         impl CommonCliOptions for Diff {
             fn input(&self) -> &path::Path {
                 &self.old_input
+            }
+
+            fn parse_mode(&self) -> traits::ParseMode {
+                self.parse_mode
             }
 
             fn output_destination(&self) -> &OutputDestination {
@@ -157,6 +191,10 @@ cfg_if! {
         impl CommonCliOptions for Garbage {
             fn input(&self) -> &path::Path {
                 &self.input
+            }
+
+            fn parse_mode(&self) -> traits::ParseMode {
+                self.parse_mode
             }
 
             fn output_destination(&self) -> &OutputDestination {

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -22,4 +22,4 @@ twiggy-traits = { version = "=0.3.0", path = "../traits" }
 
 [features]
 default = ["dwarf"]
-dwarf = ["fallible-iterator", "gimli", "object", "typed-arena"]
+dwarf = ["fallible-iterator", "gimli", "object", "typed-arena", "twiggy-traits/dwarf"]

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -20,7 +20,7 @@ csv = "1.0.2"
 regex = "1.0.5"
 
 [features]
-default = ["dwarf"]
+default = []
 dwarf = ["gimli"]
 emit_json = []
 emit_csv = []

--- a/traits/traits.rs
+++ b/traits/traits.rs
@@ -144,6 +144,38 @@ pub trait Analyze {
     fn analyze(items: &mut ir::Items) -> Result<Self::Data, Error>;
 }
 
+/// Selects the parse mode for the input data.
+#[derive(Clone, Copy, Debug)]
+pub enum ParseMode {
+    /// WebAssembly file parse mode.
+    Wasm,
+    /// DWARF sections parse mode.
+    #[cfg(feature = "dwarf")]
+    Dwarf,
+    /// Automatically determined mode of parsing, e.g. based on file extension.
+    Auto,
+}
+
+impl Default for ParseMode {
+    fn default() -> ParseMode {
+        ParseMode::Auto
+    }
+}
+
+impl FromStr for ParseMode {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "wasm" => Ok(ParseMode::Wasm),
+            #[cfg(feature = "dwarf")]
+            "dwarf" => Ok(ParseMode::Dwarf),
+            "auto" => Ok(ParseMode::Auto),
+            _ => Err(Error::with_msg(format!("Unknown parse mode: {}", s))),
+        }
+    }
+}
+
 /// The format of the output.
 #[derive(Clone, Copy, Debug)]
 pub enum OutputFormat {

--- a/traits/traits.rs
+++ b/traits/traits.rs
@@ -6,6 +6,7 @@
 extern crate csv;
 #[macro_use]
 extern crate failure;
+#[cfg(feature = "dwarf")]
 extern crate gimli;
 extern crate regex;
 

--- a/twiggy/twiggy.rs
+++ b/twiggy/twiggy.rs
@@ -27,7 +27,7 @@ fn main() {
 }
 
 fn run(opts: &opt::Options) -> Result<(), traits::Error> {
-    let mut items = parser::read_and_parse(opts.input())?;
+    let mut items = parser::read_and_parse(opts.input(), opts.parse_mode())?;
 
     let data = match opts {
         opt::Options::Top(ref top) => analyze::top(&mut items, top)?,
@@ -36,7 +36,7 @@ fn run(opts: &opt::Options) -> Result<(), traits::Error> {
         opt::Options::Monos(ref monos) => analyze::monos(&mut items, monos)?,
         opt::Options::Garbage(ref garbo) => analyze::garbage(&items, garbo)?,
         opt::Options::Diff(ref diff) => {
-            let mut new_items = parser::read_and_parse(diff.new_input())?;
+            let mut new_items = parser::read_and_parse(diff.new_input(), opts.parse_mode())?;
             analyze::diff(&mut items, &mut new_items, diff)?
         }
     };

--- a/wasm-api/Cargo.toml
+++ b/wasm-api/Cargo.toml
@@ -13,6 +13,7 @@ version = "=0.3.0"
 path = "../ir"
 
 [dependencies.twiggy-analyze]
+default-features = false
 version = "=0.3.0"
 path = "../analyze"
 features = ["emit_json"]


### PR DESCRIPTION
Currently, file extension is used to determine the mode.

Adding the option/argument to choose the parsing mode will allow:

- To choose DWARF sections in the wasm file as input data;
- To choose WASM parser when ".wasm" extension is not specified.