### PR TITLE
Bump parity-wasm to 0.35.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "parity-wasm"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -538,7 +538,7 @@ dependencies = [
  "fallible-iterator 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gimli 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "object 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-wasm 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-wasm 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "twiggy-ir 0.3.0",
  "twiggy-traits 0.3.0",
  "typed-arena 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -551,7 +551,7 @@ dependencies = [
  "csv 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gimli 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-wasm 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-wasm 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "twiggy-ir 0.3.0",
 ]
@@ -718,7 +718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum object 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6cca6ad89d0801138cb4ef606908ae12d83edc4c790ef5178fc7b4c72d959e90"
 "checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
 "checksum parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)" = "511379a8194230c2395d2f5fa627a5a7e108a9f976656ce723ae68fca4097bfc"
-"checksum parity-wasm 0.34.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e50c08cad52d745aad8305c6175d05ae3e241b53200bdc58a82aa64f9b3e0d1e"
+"checksum parity-wasm 0.35.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44c8d82f4abd3f6dc5667e2e953ba27f4ce2293940a774bf317b76c70860107a"
 "checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
 "checksum plain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 "checksum proc-macro2 0.4.18 (registry+https://github.com/rust-lang/crates.io-index)" = "afa4d377067cc02eb5e0b491d3f7cfbe145ad4da778535bfb13c444413dd35b9"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -15,7 +15,7 @@ path = "./parser.rs"
 fallible-iterator = { version = "0.1.5", optional = true }
 gimli = { version = "0.16.1", optional = true }
 object = { version = "0.10.0", optional = true }
-parity-wasm = "0.34.0"
+parity-wasm = "0.35.0"
 typed-arena = { version = "1.4.0", optional = true }
 twiggy-ir = { version = "=0.3.0", path = "../ir" }
 twiggy-traits = { version = "=0.3.0", path = "../traits" }

--- a/parser/wasm_parse/mod.rs
+++ b/parser/wasm_parse/mod.rs
@@ -745,8 +745,12 @@ impl<'a> Parse<'a> for elements::DataSection {
             let size = serialized_size(d.clone())?; // serialized size
             let length = d.value().len(); // size of data
             let ty = None;
-            let offset_code = d.offset().code();
-            let offset = offset_code.get(0).and_then(|op| match *op {
+
+            // Get the constant address (if any) from the initialization
+            // expression.
+            let offset_exp = d.offset();
+            let offset_code = offset_exp.as_ref().map(|e| e.code());
+            let offset = offset_code.and_then(|c| c.get(0)).and_then(|op| match *op {
                 I32Const(o) => Some(i64::from(o)),
                 I64Const(o) => Some(o),
                 _ => None,

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -14,7 +14,7 @@ path = "./traits.rs"
 [dependencies]
 failure = "0.1.2"
 gimli = { version = "0.16.1", optional = true }
-parity-wasm = "0.34.0"
+parity-wasm = "0.35.0"
 twiggy-ir = { version = "=0.3.0", path = "../ir" }
 csv = "1.0.2"
 regex = "1.0.5"


### PR DESCRIPTION
This bump wasn't automatic because some APIs that we use changed.