### PR TITLE
Skip the cpp demangler when symbols don't have the C++ prefixes

### DIFF
--- a/ir/ir.rs
+++ b/ir/ir.rs
@@ -589,6 +589,29 @@ impl Code {
             return Some(sym.to_string());
         }
 
+        // If the Rust demangle failed, we'll try C or C++.  C++
+        // symbols almost all start with the prefixes "_Z", "__Z", and
+        // ""_GLOBAL_", except for a special case.
+        //
+        // Per cpp_mangle::ast::MangledName::parse:
+        //
+        // > The libiberty tests also specify that a type can be top level,
+        // > and they are not prefixed with "_Z".
+        //
+        // Therefore cpp_demangle will parse unmangled symbols, at
+        // least sometimes incorrectly (e.g. with OpenSSL's RC4
+        // function, which is incorrectly parsed as a type ctor/dtor),
+        // which confuses a subsequent `demangle` function, resulting
+        // in panic.
+        //
+        // To avoid that, only pass C++-mangled symbols to the C++
+        // demangler
+        if !s.starts_with("_Z") &&
+            !s.starts_with("__Z") &&
+            !s.starts_with("_GLOBAL_") {
+            return Some(s.to_string());
+        }
+
         if let Ok(sym) = cpp_demangle::Symbol::new(s) {
             return Some(sym.to_string());
         }


### PR DESCRIPTION
cpp_mangler doesn't seem to handle plain unmangled C symbols correctly,
which can result in panics during stringification.

This workaround assumes that symbols not beginning with "_Z",
"__Z", or "\_GLOBAL\_" are not C++, and uses them as is.

This change allows twiggy to analyze the TiKV dwarf binary on linux without crashing.

More explanation in the code comments. I ran into this when cpp_demangle tried to stringify "RC4", an OpenSSL function, thinking it was a CtorDtor type. cpp_demangle might be able to fix this upstream, but I don't know enough about it.

r? @fitzgen 