### PR TITLE
add formatting and linting to CI, update docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,21 @@ matrix:
         keep-history: false
         on:
           branch: master
+    - rust: stable
+      env: JOB="format"
+      before_script:
+        - rustup component add rustfmt --toolchain stable
+      script:
+        - cargo fmt -- --check
+    - rust: stable
+      env: JOB="lint"
+      before_script:
+        - rustup component add clippy --toolchain stable
+      script:
+        - cargo clippy -- -D warnings
+  allow_failures:
+    - rust: stable
+      env: JOB="lint"
 
 script:
   - ./ci/script.sh

--- a/guide/src/contributing/code-formatting.md
+++ b/guide/src/contributing/code-formatting.md
@@ -7,7 +7,7 @@ You can install the latest version of `rustfmt` with this command:
 
 ```
 $ rustup update
-$ rustup component add rustfmt-preview --toolchain nightly
+$ rustup component add rustfmt --toolchain stable
 ```
 
 Ensure that `~/.rustup/toolchains/$YOUR_HOST_TARGET/bin/` is on your `$PATH`.
@@ -16,5 +16,25 @@ Once that is taken care of, you can (re)format all code by running this command
 from the root of the repository:
 
 ```
-$ cargo +nightly fmt --all
+$ cargo fmt --all
+```
+
+# Linting
+
+We use [`clippy`](https://github.com/rust-lang/rust-clippy) to lint the codebase.
+This helps avoid common mistakes, and ensures that code is correct,
+performant, and idiomatic.
+
+You can install the latest version of `clippy` with this command:
+
+```
+$ rustup update
+$ rustup component add clippy --toolchain stable
+```
+
+Once that is complete, you can lint your code to check for mistakes by running
+this command from the root of the repository:
+
+```
+$ cargo clippy
 ```


### PR DESCRIPTION
Fixes (part of) #251.

Adds a formatting check, and an optional linting check to CI builds. This also updates the contributing docs to reflect the current way to install `rustfmt` and `clippy`.

__NOTE:__ I haven't included the actual formatting changes here, because that will be very noisy. I'd like to see this cause a PR to _fail_, so I can make the formatting changes, merge those, and then see this build pass once it has been rebased.