### PR TITLE
apply cargo fmt to codebase

### DIFF
--- a/analyze/analyses/diff.rs
+++ b/analyze/analyses/diff.rs
@@ -127,7 +127,7 @@ pub fn diff(
                 return Err(traits::Error::with_msg(format!(
                     "Could not find item with name `{}`",
                     name
-                )))
+                )));
             }
         };
         Ok(DiffEntry { name, delta })

--- a/analyze/analyses/garbage.rs
+++ b/analyze/analyses/garbage.rs
@@ -36,9 +36,11 @@ impl traits::Emit for Garbage {
             ]);
         }
 
-        match items_iter.clone()
+        match items_iter
+            .clone()
             .skip(self.limit)
-            .fold((0, 0), |(size, cnt), item| (size + item.size(), cnt + 1)) {
+            .fold((0, 0), |(size, cnt), item| (size + item.size(), cnt + 1))
+        {
             (size, cnt) if cnt > 0 => {
                 let size_percent = f64::from(size) / f64::from(items.size()) * 100.0;
                 table.add_row(vec![
@@ -64,7 +66,10 @@ impl traits::Emit for Garbage {
             table.add_row(vec![
                 total_size.to_string(),
                 format!("{:.2}%", size_percent),
-                format!("{} potential false-positive data segments", self.data_segments.len()),
+                format!(
+                    "{} potential false-positive data segments",
+                    self.data_segments.len()
+                ),
             ]);
         }
 
@@ -115,7 +120,10 @@ impl traits::Emit for Garbage {
         }
 
         if self.data_segments.len() > 0 {
-            let name = format!("{} potential false-positive data segments", self.data_segments.len());
+            let name = format!(
+                "{} potential false-positive data segments",
+                self.data_segments.len()
+            );
             let size: u32 = self.data_segments.iter().map(|&id| items[id].size()).sum();
             let size_percent = f64::from(size) / f64::from(items.size()) * 100.0;
 
@@ -156,10 +164,7 @@ pub fn garbage(items: &ir::Items, opts: &opt::Garbage) -> Result<Box<traits::Emi
             .map(|item| item.id())
             .collect();
     } else {
-        items_non_data = unreachable_items
-            .iter()
-            .map(|item| item.id())
-            .collect();
+        items_non_data = unreachable_items.iter().map(|item| item.id()).collect();
     }
 
     let garbage_items = Garbage {

--- a/analyze/analyses/monos.rs
+++ b/analyze/analyses/monos.rs
@@ -72,7 +72,8 @@ impl traits::Emit for Monos {
                 size: *size,
                 size_percent: get_size_percent(*size),
                 name: name.to_string(),
-            }).chain(insts.iter().map(move |(name, size)| TableRow {
+            })
+            .chain(insts.iter().map(move |(name, size)| TableRow {
                 bloat: None,
                 bloat_percent: None,
                 size: *size,
@@ -222,7 +223,8 @@ pub fn monos(items: &mut ir::Items, opts: &opt::Monos) -> Result<Box<traits::Emi
                 } else {
                     None
                 }
-            }).fold(BTreeMap::new(), |mut monos, (generic, inst)| {
+            })
+            .fold(BTreeMap::new(), |mut monos, (generic, inst)| {
                 monos
                     .entry(generic)
                     .or_insert_with(BTreeSet::new)
@@ -238,7 +240,8 @@ pub fn monos(items: &mut ir::Items, opts: &opt::Monos) -> Result<Box<traits::Emi
                     b_size.cmp(a_size).then(a_name.cmp(b_name))
                 });
                 (generic, insts)
-            }).collect()
+            })
+            .collect()
     }
 
     // Helper function usedd to summarize a sequence of `MonosEntry` objects.
@@ -292,7 +295,8 @@ pub fn monos(items: &mut ir::Items, opts: &opt::Monos) -> Result<Box<traits::Emi
             .into_iter()
             .filter_map(|(g, insts)| {
                 calculate_total_and_bloat(&insts).map(|(total, bloat)| (g, insts, total, bloat))
-            }).map(|(g, mut insts, t, b)| {
+            })
+            .map(|(g, mut insts, t, b)| {
                 // Truncate `insts` according to the relevant options before
                 // we map these values into `MonosEntry` objects.
                 if opts.only_generics() {
@@ -306,12 +310,14 @@ pub fn monos(items: &mut ir::Items, opts: &opt::Monos) -> Result<Box<traits::Emi
                     }
                 };
                 (g, insts, t, b)
-            }).map(|(name, insts, size, bloat)| MonosEntry {
+            })
+            .map(|(name, insts, size, bloat)| MonosEntry {
                 name: name.to_string(),
                 insts,
                 size,
                 bloat,
-            }).collect::<Vec<_>>();
+            })
+            .collect::<Vec<_>>();
         monos.sort();
         monos
     }

--- a/analyze/analyses/paths/paths_emit.rs
+++ b/analyze/analyses/paths/paths_emit.rs
@@ -22,21 +22,24 @@ impl traits::Emit for Paths {
             .iter()
             .flat_map(|entry| {
                 process_entry(entry, 0, self.opts.max_paths() as usize, &items, &self.opts)
-            }).map(
+            })
+            .map(
                 |TableRow {
                      size,
                      size_percent,
                      name,
                  }| {
                     vec![
-                        size.map(|size| size.to_string()).unwrap_or_else(String::new),
+                        size.map(|size| size.to_string())
+                            .unwrap_or_else(String::new),
                         size_percent
                             .map(|size_percent| format!("{:.2}%", size_percent))
                             .unwrap_or_else(String::new),
                         name,
                     ]
                 },
-            ).fold(
+            )
+            .fold(
                 Table::with_header(vec![
                     (Align::Right, "Shallow Bytes".to_string()),
                     (Align::Right, "Shallow %".to_string()),
@@ -168,7 +171,8 @@ mod emit_text_helpers {
                 "  ⬑ "
             } else {
                 ""
-            })).chain(iter::once(name))
+            }))
+            .chain(iter::once(name))
             .fold(
                 String::with_capacity(depth as usize * 4 + name.len()),
                 |mut res, s| {

--- a/ir/ir.rs
+++ b/ir/ir.rs
@@ -342,7 +342,8 @@ impl Items {
             .expect(
                 "Cannot call retained_sizes unless compute_retained_sizes \
                  has already been called",
-            ).get(&id)
+            )
+            .get(&id)
             .cloned()
             .unwrap()
     }
@@ -533,7 +534,7 @@ impl ItemKind {
     pub fn is_data(&self) -> bool {
         match self {
             ItemKind::Data(_) => true,
-            _ => false
+            _ => false,
         }
     }
 }
@@ -614,9 +615,7 @@ impl Code {
         //
         // To avoid that, only pass C++-mangled symbols to the C++
         // demangler
-        if !s.starts_with("_Z") &&
-            !s.starts_with("__Z") &&
-            !s.starts_with("_GLOBAL_") {
+        if !s.starts_with("_Z") && !s.starts_with("__Z") && !s.starts_with("_GLOBAL_") {
             return Some(s.to_string());
         }
 

--- a/parser/object_parse/compilation_unit_parse/mod.rs
+++ b/parser/object_parse/compilation_unit_parse/mod.rs
@@ -29,10 +29,7 @@ where
         extra: Self::ItemsExtra,
     ) -> Result<(), traits::Error> {
         // Destructure the extra information needed to parse items in the unit.
-        let Self::ItemsExtra {
-            unit_id,
-            dwarf,
-        } = extra;
+        let Self::ItemsExtra { unit_id, dwarf } = extra;
 
         // Initialize an entry ID counter.
         let mut entry_id = 0;
@@ -77,9 +74,7 @@ where
         items: &mut ir::ItemsBuilder,
         extra: Self::EdgesExtra,
     ) -> Result<(), traits::Error> {
-        let Self::EdgesExtra {
-            unit_id,
-        } = extra;
+        let Self::EdgesExtra { unit_id } = extra;
 
         // Initialize an entry ID counter.
         let mut entry_id = 0;

--- a/parser/object_parse/die_parse/item_name.rs
+++ b/parser/object_parse/die_parse/item_name.rs
@@ -21,8 +21,7 @@ where
     if let Some(attr) = die.attr_value(gimli::DW_AT_name)? {
         let s = dwarf.attr_string(unit, attr)?;
         Ok(Some(
-            s
-                .to_string()? // This `to_string()` creates a `Result<Cow<'_, str>, _>`.
+            s.to_string()? // This `to_string()` creates a `Result<Cow<'_, str>, _>`.
                 .to_string(), // This `to_string()` creates the String we return.
         ))
     } else {

--- a/parser/object_parse/die_parse/mod.rs
+++ b/parser/object_parse/die_parse/mod.rs
@@ -48,10 +48,9 @@ where
 
         let item: ir::Item = match self.tag() {
             gimli::DW_TAG_subprogram => {
-                if let Some(size) = DieLocationAttributes::try_from(self)?.entity_size(
-                    dwarf,
-                    unit,
-                )? {
+                if let Some(size) =
+                    DieLocationAttributes::try_from(self)?.entity_size(dwarf, unit)?
+                {
                     let id = ir::Id::entry(unit_id, entry_id);
                     let name = item_name(self, dwarf, unit)?
                         .unwrap_or_else(|| format!("Subroutine[{}][{}]", unit_id, entry_id));

--- a/parser/object_parse/mod.rs
+++ b/parser/object_parse/mod.rs
@@ -104,9 +104,7 @@ impl<'a, R: gimli::Reader> Parse<'a> for gimli::Dwarf<R> {
         let mut headers = self.units().enumerate();
         while let Some((unit_id, header)) = headers.next()? {
             let mut unit = self.unit(header)?;
-            let extra = CompUnitEdgesExtra {
-                unit_id,
-            };
+            let extra = CompUnitEdgesExtra { unit_id };
             unit.parse_edges(items, extra)?
         }
 

--- a/parser/parser.rs
+++ b/parser/parser.rs
@@ -9,9 +9,9 @@ extern crate fallible_iterator;
 extern crate gimli;
 #[cfg(feature = "dwarf")]
 extern crate object;
-extern crate wasmparser;
 #[cfg(feature = "dwarf")]
 extern crate typed_arena;
+extern crate wasmparser;
 
 extern crate twiggy_ir as ir;
 extern crate twiggy_traits as traits;
@@ -25,7 +25,10 @@ use std::io::Read;
 use std::path;
 
 /// Parse the file at the given path into IR items.
-pub fn read_and_parse<P: AsRef<path::Path>>(path: P, mode: traits::ParseMode) -> Result<ir::Items, traits::Error> {
+pub fn read_and_parse<P: AsRef<path::Path>>(
+    path: P,
+    mode: traits::ParseMode,
+) -> Result<ir::Items, traits::Error> {
     let path = path.as_ref();
     let mut file = fs::File::open(path)?;
     let mut data = vec![];
@@ -35,15 +38,13 @@ pub fn read_and_parse<P: AsRef<path::Path>>(path: P, mode: traits::ParseMode) ->
         traits::ParseMode::Wasm => parse_wasm(&data),
         #[cfg(feature = "dwarf")]
         traits::ParseMode::Dwarf => parse_other(&data),
-        traits::ParseMode::Auto => {
-            match path.extension().and_then(|s| s.to_str()) {
-                Some("wasm") => parse_wasm(&data),
-                #[cfg(feature = "dwarf")]
-                _ => parse_other(&data),
-                #[cfg(not(feature = "dwarf"))]
-                _ => parse_fallback(&data),
-            }
-        }
+        traits::ParseMode::Auto => match path.extension().and_then(|s| s.to_str()) {
+            Some("wasm") => parse_wasm(&data),
+            #[cfg(feature = "dwarf")]
+            _ => parse_other(&data),
+            #[cfg(not(feature = "dwarf"))]
+            _ => parse_fallback(&data),
+        },
     }
 }
 

--- a/traits/traits.rs
+++ b/traits/traits.rs
@@ -10,8 +10,8 @@ extern crate failure;
 extern crate gimli;
 extern crate regex;
 
-extern crate wasmparser;
 extern crate twiggy_ir as ir;
+extern crate wasmparser;
 
 use std::fmt;
 use std::io;

--- a/twiggy/tests/all/top_tests.rs
+++ b/twiggy/tests/all/top_tests.rs
@@ -78,10 +78,4 @@ test!(
 );
 
 // Regression test for https://github.com/rustwasm/twiggy/issues/151
-test!(
-    top_mono,
-    "top",
-    "./fixtures/mono.wasm",
-    "-n",
-    "10"
-);
+test!(top_mono, "top", "./fixtures/mono.wasm", "-n", "10");


### PR DESCRIPTION
Fixes part of #251. This contains the formatting changes to the codebase. Once this lands, we can rebase #253, and check that the build there passes :+1: 