### PR TITLE
2018 edition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ twiggy_wasm_api.d.ts
 twiggy_wasm_api.js
 twiggy_wasm_api.wasm
 twiggy_wasm_api_bg.wasm
+twiggy_wasm_api_bg.d.ts
 guide/book

--- a/analyze/Cargo.toml
+++ b/analyze/Cargo.toml
@@ -7,6 +7,7 @@ name = "twiggy-analyze"
 readme = "../README.md"
 repository = "https://github.com/rustwasm/twiggy"
 version = "0.4.0"
+edition = "2018"
 
 [lib]
 path = "./analyze.rs"

--- a/analyze/analyses/diff.rs
+++ b/analyze/analyses/diff.rs
@@ -6,8 +6,8 @@ use csv;
 use regex;
 use serde::{self, ser::SerializeStruct};
 
-use formats::json;
-use formats::table::{Align, Table};
+use crate::formats::json;
+use crate::formats::table::{Align, Table};
 use twiggy_ir as ir;
 use twiggy_opt as opt;
 use twiggy_traits as traits;

--- a/analyze/analyses/dominators/emit.rs
+++ b/analyze/analyses/dominators/emit.rs
@@ -2,15 +2,16 @@ use std::collections::BTreeMap;
 use std::io;
 
 use csv;
+use serde_derive::Serialize;
 
-use formats::json;
-use formats::table::{Align, Table};
 use twiggy_ir as ir;
 use twiggy_opt as opt;
 use twiggy_traits as traits;
 
 use super::UnreachableItemsSummary;
 use crate::analyses::dominators::DominatorTree;
+use crate::formats::json;
+use crate::formats::table::{Align, Table};
 
 impl traits::Emit for DominatorTree {
     #[cfg(feature = "emit_text")]

--- a/analyze/analyses/garbage.rs
+++ b/analyze/analyses/garbage.rs
@@ -3,8 +3,8 @@ use std::io;
 
 use petgraph::visit::Walker;
 
-use formats::json;
-use formats::table::{Align, Table};
+use crate::formats::json;
+use crate::formats::table::{Align, Table};
 use twiggy_ir as ir;
 use twiggy_opt as opt;
 use twiggy_traits as traits;

--- a/analyze/analyses/monos.rs
+++ b/analyze/analyses/monos.rs
@@ -4,9 +4,10 @@ use std::io;
 use std::iter;
 
 use csv;
+use serde_derive::Serialize;
 
-use formats::json;
-use formats::table::{Align, Table};
+use crate::formats::json;
+use crate::formats::table::{Align, Table};
 use twiggy_ir as ir;
 use twiggy_opt as opt;
 use twiggy_traits as traits;

--- a/analyze/analyses/paths/paths_emit.rs
+++ b/analyze/analyses/paths/paths_emit.rs
@@ -2,12 +2,11 @@ use std::io;
 
 use csv;
 
-use formats::json;
-use formats::table::{Align, Table};
+use crate::analyses::paths::Paths;
+use crate::formats::json;
+use crate::formats::table::{Align, Table};
 use twiggy_ir as ir;
 use twiggy_traits as traits;
-
-use analyses::paths::Paths;
 
 impl traits::Emit for Paths {
     #[cfg(feature = "emit_text")]
@@ -99,12 +98,10 @@ impl traits::Emit for Paths {
 /// This module contains helper functions and structs used by the `emit_text`
 /// method in Path's implementation of the `traits::Emit` trait.
 mod emit_text_helpers {
+    use crate::analyses::paths::paths_entry::PathsEntry;
     use std::iter;
-
     use twiggy_ir::Items;
     use twiggy_opt::Paths;
-
-    use analyses::paths::paths_entry::PathsEntry;
 
     /// This structure represents a row in the emitted text table. Size, and size
     /// percentage are only shown for the top-most rows.
@@ -186,13 +183,11 @@ mod emit_text_helpers {
 /// This module contains helper functions and structs used by the `emit_json`
 /// method in Path's implementation of the `traits::Emit` trait.
 mod emit_json_helpers {
+    use crate::analyses::paths::paths_entry::PathsEntry;
+    use crate::formats::json::Object;
     use std::io;
-
-    use formats::json::Object;
     use twiggy_ir::Items;
     use twiggy_opt::Paths;
-
-    use analyses::paths::paths_entry::PathsEntry;
 
     // Process a paths entry, by adding its name and size to the given JSON object.
     pub(super) fn process_entry(
@@ -228,12 +223,11 @@ mod emit_json_helpers {
 /// This module contains helper functions and structs used by the `emit_csv`
 /// method in Path's implementation of the `traits::Emit` trait.
 mod emit_csv_helpers {
+    use crate::analyses::paths::paths_entry::PathsEntry;
+    use serde_derive::Serialize;
     use std::iter;
-
     use twiggy_ir::Items;
     use twiggy_opt::Paths;
-
-    use analyses::paths::paths_entry::PathsEntry;
 
     /// This structure represents a row in the CSV output.
     #[derive(Serialize, Debug)]

--- a/analyze/analyses/paths/paths_emit.rs
+++ b/analyze/analyses/paths/paths_emit.rs
@@ -97,6 +97,7 @@ impl traits::Emit for Paths {
 
 /// This module contains helper functions and structs used by the `emit_text`
 /// method in Path's implementation of the `traits::Emit` trait.
+#[cfg(feature = "emit_text")]
 mod emit_text_helpers {
     use crate::analyses::paths::paths_entry::PathsEntry;
     use std::iter;
@@ -182,6 +183,7 @@ mod emit_text_helpers {
 
 /// This module contains helper functions and structs used by the `emit_json`
 /// method in Path's implementation of the `traits::Emit` trait.
+#[cfg(feature = "emit_json")]
 mod emit_json_helpers {
     use crate::analyses::paths::paths_entry::PathsEntry;
     use crate::formats::json::Object;
@@ -222,6 +224,7 @@ mod emit_json_helpers {
 
 /// This module contains helper functions and structs used by the `emit_csv`
 /// method in Path's implementation of the `traits::Emit` trait.
+#[cfg(feature = "emit_csv")]
 mod emit_csv_helpers {
     use crate::analyses::paths::paths_entry::PathsEntry;
     use serde_derive::Serialize;

--- a/analyze/analyses/top.rs
+++ b/analyze/analyses/top.rs
@@ -1,9 +1,10 @@
 use std::io;
 
 use csv;
+use serde_derive::Serialize;
 
-use formats::json;
-use formats::table::{Align, Table};
+use crate::formats::json;
+use crate::formats::table::{Align, Table};
 use twiggy_ir as ir;
 use twiggy_opt as opt;
 use twiggy_traits as traits;

--- a/analyze/analyze.rs
+++ b/analyze/analyze.rs
@@ -3,16 +3,6 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate csv;
-extern crate petgraph;
-extern crate regex;
-extern crate twiggy_ir;
-extern crate twiggy_opt;
-extern crate twiggy_traits;
-
 mod analyses;
 mod formats;
 

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -7,6 +7,7 @@ name = "twiggy-ir"
 readme = "../README.md"
 repository = "https://github.com/rustwasm/twiggy"
 version = "0.4.0"
+edition = "2018"
 
 [lib]
 path = "./ir.rs"

--- a/ir/ir.rs
+++ b/ir/ir.rs
@@ -3,11 +3,6 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 
-extern crate cpp_demangle;
-extern crate frozen;
-extern crate petgraph;
-extern crate rustc_demangle;
-
 mod graph_impl;
 
 use frozen::Frozen;
@@ -648,7 +643,7 @@ impl Code {
             let idx2 = demangled.rfind("::").unwrap();
             assert!(idx2 >= idx);
             if idx2 == idx {
-                let mut generic = demangled[..idx].to_string();
+                let generic = demangled[..idx].to_string();
                 return Some(generic);
             }
         }

--- a/opt/Cargo.toml
+++ b/opt/Cargo.toml
@@ -7,6 +7,7 @@ name = "twiggy-opt"
 readme = "../README.md"
 repository = "https://github.com/rustwasm/twiggy"
 version = "0.4.0"
+edition = "2018"
 
 [lib]
 path = "opt.rs"

--- a/opt/build.rs
+++ b/opt/build.rs
@@ -1,5 +1,3 @@
-extern crate regex;
-
 use std::env;
 use std::fs;
 use std::io::{self, BufRead, Write};

--- a/opt/definitions.rs
+++ b/opt/definitions.rs
@@ -9,6 +9,8 @@
 //
 // It's terrible! But it works for now.
 
+use structopt::StructOpt;
+
 /// Options for configuring `twiggy`.
 #[derive(Clone, Debug)]
 #[derive(StructOpt)]

--- a/opt/opt.rs
+++ b/opt/opt.rs
@@ -2,18 +2,13 @@
 
 #![deny(missing_debug_implementations)]
 
-#[macro_use]
-extern crate cfg_if;
-
-extern crate twiggy_traits as traits;
+use cfg_if::cfg_if;
+use twiggy_traits as traits;
 
 cfg_if! {
     if #[cfg(feature = "cli")] {
-        #[macro_use]
-        extern crate structopt;
         include!(concat!(env!("OUT_DIR"), "/cli.rs"));
     } else if #[cfg(feature = "wasm")] {
-        extern crate wasm_bindgen;
         use wasm_bindgen::prelude::*;
         include!(concat!(env!("OUT_DIR"), "/wasm.rs"));
     } else {

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -7,6 +7,7 @@ name = "twiggy-parser"
 readme = "../README.md"
 repository = "https://github.com/rustwasm/twiggy"
 version = "0.4.0"
+edition = "2018"
 
 [lib]
 path = "./parser.rs"

--- a/parser/object_parse/compilation_unit_parse/mod.rs
+++ b/parser/object_parse/compilation_unit_parse/mod.rs
@@ -1,6 +1,6 @@
 use gimli;
-use ir;
-use traits;
+use twiggy_ir as ir;
+use twiggy_traits as traits;
 
 use super::die_parse::DieItemsExtra;
 use super::Parse;

--- a/parser/object_parse/die_parse/location_attrs.rs
+++ b/parser/object_parse/die_parse/location_attrs.rs
@@ -1,6 +1,6 @@
 use fallible_iterator::FallibleIterator;
 use gimli;
-use traits;
+use twiggy_traits as traits;
 
 use super::FallilbleOption;
 

--- a/parser/object_parse/die_parse/mod.rs
+++ b/parser/object_parse/die_parse/mod.rs
@@ -1,14 +1,13 @@
 use gimli;
-use ir;
-use traits;
-
-use super::Parse;
+use twiggy_ir as ir;
+use twiggy_traits as traits;
 
 mod item_name;
 mod location_attrs;
 
 use self::item_name::item_name;
 use self::location_attrs::DieLocationAttributes;
+use super::Parse;
 
 /// This type alias is used to represent an option return value for
 /// a procedure that could return an Error.

--- a/parser/object_parse/mod.rs
+++ b/parser/object_parse/mod.rs
@@ -1,17 +1,17 @@
+use std::borrow::{Borrow, Cow};
+
 use fallible_iterator::FallibleIterator;
 use gimli;
-use ir;
 use object::{self, Object};
-use std::borrow::{Borrow, Cow};
-use traits;
+use twiggy_ir as ir;
+use twiggy_traits as traits;
 use typed_arena::Arena;
-
-use super::Parse;
 
 mod compilation_unit_parse;
 mod die_parse;
 
 use self::compilation_unit_parse::{CompUnitEdgesExtra, CompUnitItemsExtra};
+use super::Parse;
 
 // Helper function used to load a given section of the file.
 fn load_section<'a, 'file, 'input, Sect, Endian>(

--- a/parser/parser.rs
+++ b/parser/parser.rs
@@ -3,27 +3,17 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 
-#[cfg(feature = "dwarf")]
-extern crate fallible_iterator;
-#[cfg(feature = "dwarf")]
-extern crate gimli;
-#[cfg(feature = "dwarf")]
-extern crate object;
-#[cfg(feature = "dwarf")]
-extern crate typed_arena;
-extern crate wasmparser;
-
-extern crate twiggy_ir as ir;
-extern crate twiggy_traits as traits;
-
-#[cfg(feature = "dwarf")]
-mod object_parse;
-mod wasm_parse;
-
 use std::ffi::OsStr;
 use std::fs;
 use std::io::Read;
 use std::path;
+
+use twiggy_ir as ir;
+use twiggy_traits as traits;
+
+#[cfg(feature = "dwarf")]
+mod object_parse;
+mod wasm_parse;
 
 const WASM_MAGIC_NUMBER: [u8; 4] = [0x00, 0x61, 0x73, 0x6D];
 

--- a/parser/wasm_parse/mod.rs
+++ b/parser/wasm_parse/mod.rs
@@ -1,6 +1,7 @@
 use super::Parse;
-use ir::{self, Id};
 use std::collections::HashMap;
+use twiggy_ir::{self as ir, Id};
+use twiggy_traits as traits;
 use wasmparser::SectionWithLimitedItems;
 use wasmparser::{self, Operator, SectionReader, Type};
 

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -7,6 +7,7 @@ name = "twiggy-traits"
 readme = "../README.md"
 repository = "https://github.com/rustwasm/twiggy"
 version = "0.4.0"
+edition = "2018"
 
 [lib]
 path = "./traits.rs"

--- a/traits/traits.rs
+++ b/traits/traits.rs
@@ -3,19 +3,13 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 
-extern crate csv;
-#[macro_use]
-extern crate failure;
-#[cfg(feature = "dwarf")]
-extern crate gimli;
-extern crate regex;
-
-extern crate twiggy_ir as ir;
-extern crate wasmparser;
-
 use std::fmt;
 use std::io;
 use std::str::FromStr;
+
+use failure::Fail;
+
+use twiggy_ir as ir;
 
 /// An error that ocurred in `twiggy` when parsing, analyzing, or emitting
 /// items.

--- a/twiggy/Cargo.toml
+++ b/twiggy/Cargo.toml
@@ -7,6 +7,7 @@ name = "twiggy"
 readme = "../README.md"
 repository = "https://github.com/rustwasm/twiggy"
 version = "0.4.0"
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "rustwasm/twiggy" }

--- a/twiggy/tests/all/main.rs
+++ b/twiggy/tests/all/main.rs
@@ -1,6 +1,3 @@
-extern crate colored;
-extern crate diff;
-
 use std::fs;
 use std::io::{self, Read};
 use std::path::Path;
@@ -16,13 +13,11 @@ macro_rules! test {
     ( $name:ident $( , $args:expr )* ) => {
         #[test]
         fn $name() {
-            extern crate colored;
-            extern crate diff;
-
             use std::fs;
             use std::process::Command;
             use colored::Colorize;
-            use slurp;
+            use diff;
+            use crate::slurp;
 
             let output = Command::new("cargo")
                 .arg("run")

--- a/twiggy/twiggy.rs
+++ b/twiggy/twiggy.rs
@@ -3,17 +3,15 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 
-extern crate failure;
-extern crate structopt;
-extern crate twiggy_analyze as analyze;
-extern crate twiggy_opt as opt;
-extern crate twiggy_parser as parser;
-extern crate twiggy_traits as traits;
+use std::process;
 
 use failure::Fail;
-use opt::CommonCliOptions;
-use std::process;
 use structopt::StructOpt;
+
+use twiggy_analyze as analyze;
+use twiggy_opt::{self as opt, CommonCliOptions};
+use twiggy_parser as parser;
+use twiggy_traits as traits;
 
 fn main() {
     let options = opt::Options::from_args();

--- a/wasm-api/Cargo.toml
+++ b/wasm-api/Cargo.toml
@@ -3,6 +3,7 @@ name = "twiggy-wasm-api"
 version = "0.4.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 license = "Apache-2.0/MIT"
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/wasm-api/wasm-api.rs
+++ b/wasm-api/wasm-api.rs
@@ -1,14 +1,10 @@
 #![cfg(target_arch = "wasm32")]
 #![cfg(feature = "emit_json")]
 
-extern crate wasm_bindgen;
-
-extern crate twiggy_analyze as analyze;
-extern crate twiggy_ir as ir;
-extern crate twiggy_opt as opt;
-extern crate twiggy_parser as parser;
-extern crate twiggy_traits as traits;
-
+use twiggy_analyze as analyze;
+use twiggy_ir as ir;
+use twiggy_opt as opt;
+use twiggy_parser as parser;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]


### PR DESCRIPTION
Fixes #264. Migrates each of the crates in the workspace to the 2018 edition of Rust :smile_cat: Most of the changes here are to `use ...` statements, but to help review I've divided this out into separate commits for each of the individual `twiggy-*` crates.

Along the way, I noticed that some of the build output generated by the aren't currently covered by `.gitignore`, and some of the helper functions in the paths analysis weren't covered by conditional compilation flags. I went ahead and took care of those details, because they were each very small fixes.