### PR TITLE
Bump fallible iterator to 0.2.0 [Don't Merge]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,11 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fixedbitset"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,7 +520,7 @@ dependencies = [
 name = "twiggy-parser"
 version = "0.4.0"
 dependencies = [
- "fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gimli 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "object 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "twiggy-ir 0.4.0",
@@ -679,6 +684,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eb7217124812dc5672b7476d0c2d20cfe9f7c0f1ba0904b674a9762a0212f72e"
+"checksum fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum flate2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "37847f133aae7acf82bb9577ccd8bda241df836787642654286e79679826a54b"
 "checksum frozen 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f677be708300866a6ec8ead0c71da49551867dece3fda611113cc52413fd699"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 path = "./parser.rs"
 
 [dependencies]
-fallible-iterator = { version = "0.1.6", optional = true }
+fallible-iterator = { version = "0.2.0", optional = true }
 gimli = { version = "0.17.0", optional = true, default-features = false, features = ["std", "read"] }
 object = { version = "0.11.0", optional = true }
 wasmparser = "0.29.2"

--- a/parser/object_parse/die_parse/location_attrs.rs
+++ b/parser/object_parse/die_parse/location_attrs.rs
@@ -81,8 +81,8 @@ impl<R: gimli::Reader> DieLocationAttributes<R> {
         if let Some(offset) = self.dw_at_ranges()? {
             let ranges = dwarf.ranges(unit, offset)?;
             let size = ranges
-                .map(|r| r.end - r.begin)
-                .fold(0, |res, size| res + size)?;
+                .map(|r| Ok(r.end - r.begin))
+                .fold(0, |res, size| Ok(res + size))?;
             Ok(Some(size))
         } else {
             Ok(None)


### PR DESCRIPTION
This manually fixes the problems that caused dependabot's PR #263 to fail. For some reason or another, this seems to also require `gimli-rs` to be using `0.2.0` as well? I was seeing cryptic error messages about `FallibleIterator` not being in scope, until I cloned `gimli` and updated the dependency locally.

The fix itself is adjusting our calls to the `FallibleIterator` trait's adaptor methods, so that the return a `Result<T, _>` rather than a `T`.

This shouldn't be merged until https://github.com/gimli-rs/gimli/pull/407 is merged, so I am expecting CI to fail for now. I'll rebase this / poke it again when that should be good to go :+1: 