### PR TITLE
add test for printing all items in wee_alloc diff

### DIFF
--- a/twiggy/tests/all/diff_tests.rs
+++ b/twiggy/tests/all/diff_tests.rs
@@ -14,6 +14,16 @@ test!(
     "5"
 );
 
+// TODO: Update this test once `--all` flag is added.
+test!(
+    diff_wee_alloc_all,
+    "diff",
+    "./fixtures/wee_alloc.wasm",
+    "./fixtures/wee_alloc.2.wasm",
+    "-n",
+    "100"
+);
+
 test!(
     diff_wee_alloc_json,
     "diff",

--- a/twiggy/tests/all/expectations/diff_wee_alloc_all
+++ b/twiggy/tests/all/expectations/diff_wee_alloc_all
@@ -1,0 +1,43 @@
+ Delta Bytes │ Item
+─────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+       -1034 ┊ data[3]
+        -593 ┊ "function names" subsection
+        +395 ┊ wee_alloc::alloc_first_fit::he2a4ddf96981c0ce
+        +243 ┊ goodbye
+        -225 ┊ wee_alloc::alloc_first_fit::h9a72de3af77ef93f
+        -152 ┊ wee_alloc::alloc_with_refill::hb32c1bbce9ebda8e
+        +145 ┊ <wee_alloc::neighbors::Neighbors<'a, T>>::remove::hc9e5d4284e8233b8
+        -136 ┊ <wee_alloc::size_classes::SizeClassAllocPolicy<'a> as wee_alloc::AllocPolicy>::new_cell_for_free_list::h3987e3054b8224e6
+         -76 ┊ <wee_alloc::LargeAllocPolicy as wee_alloc::AllocPolicy>::new_cell_for_free_list::h8f071b7bce0301ba
+         -25 ┊ data[1]
+         -25 ┊ data[2]
+         +15 ┊ hello
+         +15 ┊ import env::rust_oom
+         -12 ┊ elem[0]
+         +10 ┊ custom section 'linking' headers
+          +8 ┊ global[0]
+          -8 ┊ type[4]: (i32, i32, i32, i32, i32) -> nil
+          -6 ┊ <wee_alloc::LargeAllocPolicy as wee_alloc::AllocPolicy>::min_cell_size::hc7cee2a550987099
+          +6 ┊ alloc::alloc::oom::h45ae3f22a516fb04
+          -6 ┊ type[0]: (i32, i32, i32) -> nil
+          -6 ┊ type[1]: (i32, i32) -> i32
+          -5 ┊ <wee_alloc::size_classes::SizeClassAllocPolicy<'a> as wee_alloc::AllocPolicy>::min_cell_size::h6f746be886573355
+          +5 ┊ type[1]: (i32) -> i32
+          -4 ┊ __wasm_nullptr
+          +4 ┊ type[0]: () -> i32
+          -4 ┊ type[5]: () -> i32
+          -3 ┊ core::ptr::drop_in_place::h4e5cdfd7b9310648.18
+          -3 ┊ core::ptr::drop_in_place::h8e9fdc2437d43666
+          +3 ┊ custom section 'linking'
+          -3 ┊ element section headers
+          +3 ┊ global section headers
+          +3 ┊ import section headers
+          +2 ┊ data[0]
+          -1 ┊ data section headers
+          -1 ┊ func[10]
+          -1 ┊ func[5]
+          -1 ┊ func[6]
+          -1 ┊ func[7]
+          -1 ┊ func[8]
+          -1 ┊ func[9]
+       -1476 ┊ Σ [40 Total Rows]


### PR DESCRIPTION
While working on solving #174, I noticed that the current snapshot tests don't display enough rows to include any function items in the output. This backfills a test to show all of the rows in the diff.

Note: We don't have an `--all` flag on the diff command yet, which is being tracked in #109. Once that is done for the `diff` subcommand, we should update this test. For now, I am using `-n 100` to print all of the items.