### PR TITLE
resolving clippy warning about match on bool

### DIFF
--- a/parser/parser.rs
+++ b/parser/parser.rs
@@ -68,10 +68,12 @@ pub(crate) trait Parse<'a> {
 fn parse_auto(extension: Option<&str>, data: &[u8]) -> Result<ir::Items, traits::Error> {
     if sniff_wasm(extension, &data) {
         parse_wasm(&data)
-    } else if cfg!(feature = "dwarf") {
-        parse_other(&data)
     } else {
-        parse_fallback(&data)
+        #[cfg(feature = "dwarf")]
+        let res = parse_other(&data);
+        #[cfg(not(feature = "dwarf"))]
+        let res = parse_fallback(&data);
+        res
     }
 }
 


### PR DESCRIPTION
small change, to fix this error that was popping up in the "lint" job in CI: https://travis-ci.com/rustwasm/twiggy/jobs/208678855#L371

```
error: you seem to be trying to match on a boolean expression
  --> parser/./parser.rs:34:36
   |
34 |           traits::ParseMode::Auto => match sniff_wasm(path.extension(), &data[..]) {
   |  ____________________________________^
35 | |             true => parse_wasm(&data),
36 | |             #[cfg(feature = "dwarf")]
37 | |             _ => parse_other(&data),
38 | |             #[cfg(not(feature = "dwarf"))]
39 | |             _ => parse_fallback(&data),
40 | |         },
   | |_________^ help: consider using an if/else expression: `if sniff_wasm(path.extension(), &data[..]) { parse_wasm(&data) } else { parse_other(&data) }`
   |
   = note: `-D clippy::match-bool` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_bool
```