### PR TITLE
Update guide examples

### DIFF
--- a/guide/src/usage/as-a-crate.md
+++ b/guide/src/usage/as-a-crate.md
@@ -30,5 +30,5 @@ fn main() {
 }
 ```
 
-For a more in-depth example, take a look at is the implementation of the
+For a more in-depth example, take a look at the implementation of the
 `twiggy` CLI crate.

--- a/guide/src/usage/command-line-interface/diff.md
+++ b/guide/src/usage/command-line-interface/diff.md
@@ -4,15 +4,13 @@ The `twiggy diff` sub-command computes the delta size of each item between old
 and new versions of a binary.
 
 ```
-$ twiggy diff path/to/old.wasm path/to/new.wasm
  Delta Bytes │ Item
-─────────────┼────────────────────────────────────────────────────────────────────
-       -1476 ┊ <total>
+─────────────┼──────────────────────────────────────────────
        -1034 ┊ data[3]
         -593 ┊ "function names" subsection
-        +395 ┊ wee_alloc::alloc_first_fit::he2a4ddf96981c0ce
+        +396 ┊ wee_alloc::alloc_first_fit::he2a4ddf96981c0ce
         +243 ┊ goodbye
-        -225 ┊ wee_alloc::alloc_first_fit::h9a72de3af77ef93f
-        -152 ┊ wee_alloc::alloc_with_refill::hb32c1bbce9ebda8e
-        +145 ┊ <wee_alloc::neighbors::Neighbors<'a, T>>::remove::hc9e5d4284e8233b8
+        -226 ┊ wee_alloc::alloc_first_fit::h9a72de3af77ef93f
+        -262 ┊ ... and 29 more.
+       -1476 ┊ Σ [34 Total Rows]
 ```

--- a/guide/src/usage/command-line-interface/dominators.md
+++ b/guide/src/usage/command-line-interface/dominators.md
@@ -4,20 +4,14 @@ The `twiggy dominators` sub-command displays the dominator tree of a binary's
 call graph.
 
 ```
-$ twiggy dominators path/to/input.wasm
  Retained Bytes │ Retained % │ Dominator Tree
-────────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-         284691 ┊     47.92% ┊ export "items_parse"
-         284677 ┊     47.91% ┊   ⤷ func[17]
-         284676 ┊     47.91% ┊       ⤷ items_parse
-         128344 ┊     21.60% ┊           ⤷ func[47]
-         128343 ┊     21.60% ┊               ⤷ twiggy_parser::wasm::<impl twiggy_parser::Parse<'a> for parity_wasm::elements::module::Module>::parse_items::h033e4aa1338b4363
-          98403 ┊     16.56% ┊           ⤷ func[232]
-          98402 ┊     16.56% ┊               ⤷ twiggy_ir::demangle::h7fb5cfffc912bc2f
-          34206 ┊      5.76% ┊           ⤷ func[20]
-          34205 ┊      5.76% ┊               ⤷ <parity_wasm::elements::section::Section as parity_wasm::elements::Deserialize>::deserialize::hdd814798147ca8dc
-           2855 ┊      0.48% ┊           ⤷ func[552]
-           2854 ┊      0.48% ┊               ⤷ <alloc::btree::map::BTreeMap<K, V>>::insert::he64f84697ccf122d
-           1868 ┊      0.31% ┊           ⤷ func[53]
-           1867 ┊      0.31% ┊               ⤷ twiggy_ir::ItemsBuilder::finish::h1b98f5cc4c80137d
+────────────────┼────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+         175726 ┊     14.99% ┊ export "items_parse"
+         175712 ┊     14.98% ┊   ⤷ items_parse
+         131407 ┊     11.21% ┊       ⤷ twiggy_parser::wasm_parse::<impl twiggy_parser::Parse for wasmparser::readers::module::ModuleReader>::parse_items::h39c45381d868d181
+          18492 ┊      1.58% ┊       ⤷ wasmparser::binary_reader::BinaryReader::read_operator::hb1c7cde18e148939
+           2677 ┊      0.23% ┊       ⤷ alloc::collections::btree::map::BTreeMap<K,V>::insert::hd2463626e5ac3441
+           1349 ┊      0.12% ┊       ⤷ wasmparser::readers::module::ModuleReader::read::hb76af8efd547784f
+           1081 ┊      0.09% ┊       ⤷ core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &mut F>::call_once::h1ff7fe5b944492c3
+            776 ┊      0.07% ┊       ⤷ <wasmparser::readers::import_section::ImportSectionReader as wasmparser::readers::section_reader::SectionReader>::read::h12903e6d8d4091bd
 ```

--- a/guide/src/usage/command-line-interface/garbage.md
+++ b/guide/src/usage/command-line-interface/garbage.md
@@ -4,16 +4,13 @@ The `twiggy garbage` sub-command finds and displays dead code and data that is
 not transitively referenced by any exports or public functions.
 
 ```
-$ twiggy garbage path/to/input.wasm
  Bytes │ Size % │ Garbage Item
-───────┼────────┼──────────────────────
-    11 ┊  5.58% ┊ unusedAddThreeNumbers
-     8 ┊  4.06% ┊ unusedAddOne
-     7 ┊  3.55% ┊ type[2]
-     5 ┊  2.54% ┊ type[1]
-     5 ┊  2.54% ┊ unusedChild
-     4 ┊  2.03% ┊ type[0]
-     1 ┊  0.51% ┊ func[0]
-     1 ┊  0.51% ┊ func[1]
-     1 ┊  0.51% ┊ func[2]
+───────┼────────┼────────────────────────────────
+    12 ┊  6.09% ┊ unusedAddThreeNumbers
+     9 ┊  4.57% ┊ unusedAddOne
+     7 ┊  3.55% ┊ type[2]: (i32, i32, i32) -> i32
+     6 ┊  3.05% ┊ unusedChild
+     5 ┊  2.54% ┊ type[1]: (i32) -> i32
+     4 ┊  2.03% ┊ type[0]: () -> i32
+    43 ┊ 21.83% ┊ Σ [6 Total Rows]
 ```

--- a/guide/src/usage/command-line-interface/monos.md
+++ b/guide/src/usage/command-line-interface/monos.md
@@ -4,16 +4,17 @@ The `twiggy monos` sub-command lists the generic function monomorphizations that
 are contributing to code bloat.
 
 ```
-$ twiggy monos path/to/input.wasm
- Apprx. Bloat Bytes │ Apprx. Bloat % │ Bytes │ %     │ Monomorphizations
-────────────────────┼────────────────┼───────┼───────┼────────────────────────────────────────────────────────
-               1977 ┊          3.40% ┊  3003 ┊ 5.16% ┊ alloc::slice::merge_sort
-                    ┊                ┊  1026 ┊ 1.76% ┊     alloc::slice::merge_sort::hb3d195f9800bdad6
-                    ┊                ┊  1026 ┊ 1.76% ┊     alloc::slice::merge_sort::hfcf2318d7dc71d03
-                    ┊                ┊   951 ┊ 1.63% ┊     alloc::slice::merge_sort::hcfca67f5c75a52ef
-               1302 ┊          2.24% ┊  3996 ┊ 6.87% ┊ <&'a T as core::fmt::Debug>::fmt
-                    ┊                ┊  2694 ┊ 4.63% ┊     <&'a T as core::fmt::Debug>::fmt::h1c27955d8de3ff17
-                    ┊                ┊   568 ┊ 0.98% ┊     <&'a T as core::fmt::Debug>::fmt::hea6a77c4dcddb7ac
-                    ┊                ┊   433 ┊ 0.74% ┊     <&'a T as core::fmt::Debug>::fmt::hfbacf6f5c9f53bb2
-                    ┊                ┊   301 ┊ 0.52% ┊     <&'a T as core::fmt::Debug>::fmt::h199e8e1c5752e6f1
+ Apprx. Bloat Bytes │ Apprx. Bloat % │ Bytes │ %      │ Monomorphizations
+────────────────────┼────────────────┼───────┼────────┼────────────────────────────────────────────────────────
+               2141 ┊          3.68% ┊  3249 ┊  5.58% ┊ alloc::slice::merge_sort
+                    ┊                ┊  1108 ┊  1.90% ┊     alloc::slice::merge_sort::hb3d195f9800bdad6
+                    ┊                ┊  1108 ┊  1.90% ┊     alloc::slice::merge_sort::hfcf2318d7dc71d03
+                    ┊                ┊  1033 ┊  1.77% ┊     alloc::slice::merge_sort::hcfca67f5c75a52ef
+               1457 ┊          2.50% ┊  4223 ┊  7.26% ┊ <&'a T as core::fmt::Debug>::fmt
+                    ┊                ┊  2766 ┊  4.75% ┊     <&'a T as core::fmt::Debug>::fmt::h1c27955d8de3ff17
+                    ┊                ┊   636 ┊  1.09% ┊     <&'a T as core::fmt::Debug>::fmt::hea6a77c4dcddb7ac
+                    ┊                ┊   481 ┊  0.83% ┊     <&'a T as core::fmt::Debug>::fmt::hfbacf6f5c9f53bb2
+                    ┊                ┊   340 ┊  0.58% ┊     ... and 1 more.
+               3759 ┊          6.46% ┊ 31160 ┊ 53.54% ┊ ... and 214 more.
+               7357 ┊         12.64% ┊ 38632 ┊ 66.37% ┊ Σ [223 Total Rows]
 ```

--- a/guide/src/usage/command-line-interface/paths.md
+++ b/guide/src/usage/command-line-interface/paths.md
@@ -6,15 +6,13 @@ function, why this function is not dead code, and therefore why it wasn't
 removed by the linker.
 
 ```
-$ twiggy paths path/to/wee_alloc.wasm 'wee_alloc::alloc_with_refill::hb32c1bbce9ebda8e'
  Shallow Bytes │ Shallow % │ Retaining Paths
-───────────────┼───────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-           152 ┊     5.40% ┊ wee_alloc::alloc_with_refill::hb32c1bbce9ebda8e
-               ┊           ┊   ⬑ func[2]
-               ┊           ┊       ⬑ <wee_alloc::size_classes::SizeClassAllocPolicy<'a> as wee_alloc::AllocPolicy>::new_cell_for_free_list::h3987e3054b8224e6
-               ┊           ┊           ⬑ func[5]
-               ┊           ┊               ⬑ elem[0]
-               ┊           ┊       ⬑ hello
-               ┊           ┊           ⬑ func[8]
-               ┊           ┊               ⬑ export "hello"
+───────────────┼───────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+           153 ┊     5.43% ┊ wee_alloc::alloc_with_refill::hb32c1bbce9ebda8e
+               ┊           ┊   ⬑ <wee_alloc::size_classes::SizeClassAllocPolicy<'a> as wee_alloc::AllocPolicy>::new_cell_for_free_list::h3987e3054b8224e6
+               ┊           ┊       ⬑ elem[0]
+               ┊           ┊           ⬑ table[0]
+               ┊           ┊   ⬑ hello
+               ┊           ┊       ⬑ export "hello"
+
 ```

--- a/guide/src/usage/command-line-interface/top.md
+++ b/guide/src/usage/command-line-interface/top.md
@@ -4,15 +4,18 @@ The `twiggy top` sub-command summarizes and lists the top code size offenders in
 a binary.
 
 ```
-$ twiggy top path/to/wee_alloc.wasm
  Shallow Bytes │ Shallow % │ Item
-───────────────┼───────────┼───────────────────────────────────────────────────────────────────────────────────────────────────
+───────────────┼───────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
           1034 ┊    36.71% ┊ data[3]
-           774 ┊    27.48% ┊ "function names" subsection
-           225 ┊     7.99% ┊ wee_alloc::alloc_first_fit::h9a72de3af77ef93f
-           164 ┊     5.82% ┊ hello
-           152 ┊     5.40% ┊ wee_alloc::alloc_with_refill::hb32c1bbce9ebda8e
-           136 ┊     4.83% ┊ <wee_alloc::size_classes::SizeClassAllocPolicy<'a> as wee_alloc::AllocPolicy>::new_cell_for_free_list::h3987e3054b8224e6
-            76 ┊     2.70% ┊ <wee_alloc::LargeAllocPolicy as wee_alloc::AllocPolicy>::new_cell_for_free_list::h8f071b7bce0301ba
-            44 ┊     1.56% ┊ goodbye
+           777 ┊    27.58% ┊ "function names" subsection
+           226 ┊     8.02% ┊ wee_alloc::alloc_first_fit::h9a72de3af77ef93f
+           165 ┊     5.86% ┊ hello
+           153 ┊     5.43% ┊ wee_alloc::alloc_with_refill::hb32c1bbce9ebda8e
+           137 ┊     4.86% ┊ <wee_alloc::size_classes::SizeClassAllocPolicy<'a> as wee_alloc::AllocPolicy>::new_cell_for_free_list::h3987e3054b8224e6
+            77 ┊     2.73% ┊ <wee_alloc::LargeAllocPolicy as wee_alloc::AllocPolicy>::new_cell_for_free_list::h8f071b7bce0301ba
+            45 ┊     1.60% ┊ goodbye
+            25 ┊     0.89% ┊ data[1]
+            25 ┊     0.89% ┊ data[2]
+           153 ┊     5.43% ┊ ... and 27 more.
+          2817 ┊   100.00% ┊ Σ [37 Total Rows]
 ```

--- a/guide/src/usage/on-the-web-with-webassembly.md
+++ b/guide/src/usage/on-the-web-with-webassembly.md
@@ -4,22 +4,20 @@ First, ensure you have the `wasm32-unknown-unknown` Rust target installed and
 up-to-date:
 
 ```
-rustup install nightly
-rustup update nightly
-rustup target add wasm32-unknown-unknown --toolchain nightly
+rustup target add wasm32-unknown-unknown
 ```
 
 Next, install `wasm-bindgen`:
 
 ```
-cargo +nightly install wasm-bindgen-cli
+cargo install wasm-bindgen-cli
 ```
 
 Finally, build `twiggy`'s WebAssembly API with `wasm-bindgen`:
 
 ```
 cd twiggy/wasm-api
-cargo +nightly build --release --target wasm32-unknown-unknown
+cargo build --release --target wasm32-unknown-unknown
 wasm-bindgen ../target/wasm32-unknown-unknown/release/twiggy_wasm_api.wasm --out-dir .
 ```
 


### PR DESCRIPTION
Updates the CLI output examples in the guide, fixes a small typo, and instructions to compile for usage on the web. :books: :heavy_check_mark: 