### PR TITLE
fix #326 (help-wanted)

### DIFF
--- a/ir/ir.rs
+++ b/ir/ir.rs
@@ -50,6 +50,7 @@ impl ItemsBuilder {
         self.items.insert(id, item);
 
         let old_value = self.parsed.insert(id);
+        // panic happen as this is call 2 times with 7,
         assert!(
             old_value,
             "should not parse the same key into multiple items"

--- a/parser/wasm_parse/mod.rs
+++ b/parser/wasm_parse/mod.rs
@@ -125,12 +125,18 @@ impl<'a> Parse<'a> for wasmparser::ModuleReader<'a> {
                     section.get_data_section_reader()?.parse_items(items, idx)?;
                 }
                 wasmparser::SectionCode::DataCount => {
+                    let msg = "the last iteration of the loop take 7 as id";
+                    dbg!(msg, idx);
                     DataCountSection(section).parse_items(items, idx)?;
                 }
                 wasmparser::SectionCode::Code | wasmparser::SectionCode::Function => {
                     unreachable!("unexpected code or function section found");
                 }
             };
+            if idx == 7 {
+                let msg = "At some point just after the debug above this also is 7 so the panic";
+                dbg!(msg, &idx);
+            }
             let id = Id::section(idx);
             let added = items.size_added() - start;
             let size = sizes
@@ -799,8 +805,10 @@ impl<'a> Parse<'a> for DataCountSection<'a> {
     ) -> Result<(), traits::Error> {
         let range = self.0.range();
         let size = (range.end - range.start) as u32;
+        //dbg!("section", &idx);
         let id = Id::section(idx);
         let name = "\"data count\" section";
+        //dbg!("YEAH", &id);
         items.add_root(ir::Item::new(id, name, size, ir::Misc::new()));
         Ok(())
     }


### PR DESCRIPTION
[#326](https://github.com/rustwasm/twiggy/issues/326)
The `add_item` function is called two times with the same id. 
In one iteration we call successively   `DataCountSection(section).parse_items(items, idx)?;` and 
` items.add_root(ir::Item::new(id, name, size - added, ir::Misc::new()));` with the same idx value.
That why we have a panic in the `add_item` function.
I'm suppose that id is the same because section's code is also the same ? I didn't understand further