### PR TITLE
WIP - unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+**/target
 **/*.rs.bk
 Cargo.lock
 twiggy/tests/all/whatever-output.txt

--- a/analyze/Cargo.toml
+++ b/analyze/Cargo.toml
@@ -22,6 +22,9 @@ serde = "1.0.102"
 serde_derive = "1.0.102"
 petgraph = "0.4.13"
 
+[dev-dependencies]
+twiggy-opt = { version = "=0.6.0", path = "../opt", features = ["cli"] }
+
 [features]
 default = ["emit_csv", "emit_json", "emit_text"]
 emit_json = ["twiggy-traits/emit_json"]

--- a/analyze/analyses/diff.rs
+++ b/analyze/analyses/diff.rs
@@ -13,7 +13,7 @@ use twiggy_opt as opt;
 use twiggy_traits as traits;
 
 #[derive(Debug)]
-struct Diff {
+pub struct Diff {
     deltas: Vec<DiffEntry>,
 }
 
@@ -98,7 +98,7 @@ pub fn diff(
     old_items: &mut ir::Items,
     new_items: &mut ir::Items,
     opts: &opt::Diff,
-) -> Result<Box<dyn traits::Emit>, traits::Error> {
+) -> Result<Diff, traits::Error> {
     let max_items = opts.max_items() as usize;
 
     // Given a set of items, create a HashMap of the items' names and sizes.
@@ -214,6 +214,5 @@ pub fn diff(
     deltas.push(total);
 
     // Return the results so that they can be emitted.
-    let diff = Diff { deltas };
-    Ok(Box::new(diff) as Box<_>)
+    Ok(Diff { deltas })
 }

--- a/analyze/analyses/dominators/mod.rs
+++ b/analyze/analyses/dominators/mod.rs
@@ -10,13 +10,15 @@ use crate::analyses::garbage;
 
 mod emit;
 
-struct DominatorTree {
+#[derive(Debug)]
+pub struct DominatorTree {
     tree: BTreeMap<ir::Id, Vec<ir::Id>>,
     items: Vec<ir::Id>,
     opts: opt::Dominators,
     unreachable_items_summary: Option<UnreachableItemsSummary>,
 }
 
+#[derive(Debug)]
 struct UnreachableItemsSummary {
     count: usize,
     size: u32,
@@ -27,7 +29,7 @@ struct UnreachableItemsSummary {
 pub fn dominators(
     items: &mut ir::Items,
     opts: &opt::Dominators,
-) -> Result<Box<dyn traits::Emit>, traits::Error> {
+) -> Result<DominatorTree, traits::Error> {
     items.compute_dominator_tree();
     items.compute_dominators();
     items.compute_retained_sizes();
@@ -53,14 +55,12 @@ pub fn dominators(
             .collect()
     };
 
-    let tree = DominatorTree {
+    Ok(DominatorTree {
         tree: items.dominator_tree().clone(),
         items: dominator_items,
         opts: opts.clone(),
         unreachable_items_summary: summarize_unreachable_items(items, opts),
-    };
-
-    Ok(Box::new(tree) as Box<_>)
+    })
 }
 
 fn summarize_unreachable_items(

--- a/analyze/analyses/garbage.rs
+++ b/analyze/analyses/garbage.rs
@@ -10,7 +10,7 @@ use twiggy_opt as opt;
 use twiggy_traits as traits;
 
 #[derive(Debug)]
-struct Garbage {
+pub struct Garbage {
     items: Vec<ir::Id>,
     data_segments: Vec<ir::Id>,
     limit: usize,
@@ -143,10 +143,7 @@ impl traits::Emit for Garbage {
 }
 
 /// Find items that are not transitively referenced by any exports or public functions.
-pub fn garbage(
-    items: &ir::Items,
-    opts: &opt::Garbage,
-) -> Result<Box<dyn traits::Emit>, traits::Error> {
+pub fn garbage(items: &ir::Items, opts: &opt::Garbage) -> Result<Garbage, traits::Error> {
     let mut unreachable_items = get_unreachable_items(&items).collect::<Vec<_>>();
     unreachable_items.sort_by(|a, b| b.size().cmp(&a.size()));
 
@@ -171,13 +168,11 @@ pub fn garbage(
         )
     };
 
-    let garbage_items = Garbage {
+    Ok(Garbage {
         items: items_non_data,
         data_segments,
         limit: opts.max_items() as usize,
-    };
-
-    Ok(Box::new(garbage_items) as Box<_>)
+    })
 }
 
 pub(crate) fn get_unreachable_items(items: &ir::Items) -> impl Iterator<Item = &ir::Item> {

--- a/analyze/analyses/monos.rs
+++ b/analyze/analyses/monos.rs
@@ -13,7 +13,7 @@ use twiggy_opt as opt;
 use twiggy_traits as traits;
 
 #[derive(Debug)]
-struct Monos {
+pub struct Monos {
     monos: Vec<MonosEntry>,
 }
 
@@ -211,10 +211,7 @@ impl traits::Emit for Monos {
 }
 
 /// Find bloaty monomorphizations of generic functions.
-pub fn monos(
-    items: &mut ir::Items,
-    opts: &opt::Monos,
-) -> Result<Box<dyn traits::Emit>, traits::Error> {
+pub fn monos(items: &mut ir::Items, opts: &opt::Monos) -> Result<Monos, traits::Error> {
     // Type alias used to represent a map of generic function names and instantiations.
     type MonosMap<'a> = BTreeMap<&'a str, Vec<(String, u32)>>;
 
@@ -358,5 +355,5 @@ pub fn monos(
         monos.push(remaining);
     }
     monos.push(total);
-    Ok(Box::new(Monos { monos }) as Box<_>)
+    Ok(Monos { monos })
 }

--- a/analyze/analyses/paths/mod.rs
+++ b/analyze/analyses/paths/mod.rs
@@ -12,16 +12,13 @@ mod paths_entry;
 use self::paths_entry::PathsEntry;
 
 #[derive(Debug)]
-struct Paths {
+pub struct Paths {
     opts: opt::Paths,
     entries: Vec<PathsEntry>,
 }
 
 /// Find all retaining paths for the given items.
-pub fn paths(
-    items: &mut ir::Items,
-    opts: &opt::Paths,
-) -> Result<Box<dyn traits::Emit>, traits::Error> {
+pub fn paths(items: &mut ir::Items, opts: &opt::Paths) -> Result<Paths, traits::Error> {
     // The predecessor tree only needs to be computed if we are ascending
     // through the retaining paths.
     if !opts.descending() {
@@ -35,9 +32,7 @@ pub fn paths(
         .map(|id| create_entry(*id, &items, &opts, &mut BTreeSet::new()))
         .collect();
 
-    let paths = Paths { opts, entries };
-
-    Ok(Box::new(paths) as Box<_>)
+    Ok(Paths { opts, entries })
 }
 
 /// This helper function is used to collect the `ir::Id` values for the top-most

--- a/analyze/analyses/top.rs
+++ b/analyze/analyses/top.rs
@@ -9,9 +9,18 @@ use twiggy_ir as ir;
 use twiggy_opt as opt;
 use twiggy_traits as traits;
 
-struct Top {
+/// The largest items found in a binary.
+#[derive(Debug)]
+pub struct Top {
     items: Vec<ir::Id>,
     opts: opt::Top,
+}
+
+impl Top {
+    /// Get a list of the largest items.
+    pub fn items(&self) -> &[ir::Id] {
+        self.items.as_ref()
+    }
 }
 
 impl traits::Emit for Top {
@@ -209,7 +218,7 @@ impl traits::Emit for Top {
 }
 
 /// Run the `top` analysis on the given IR items.
-pub fn top(items: &mut ir::Items, opts: &opt::Top) -> Result<Box<dyn traits::Emit>, traits::Error> {
+pub fn top(items: &mut ir::Items, opts: &opt::Top) -> Result<Top, traits::Error> {
     if opts.retaining_paths() {
         return Err(traits::Error::with_msg(
             "retaining paths are not yet implemented",
@@ -237,10 +246,8 @@ pub fn top(items: &mut ir::Items, opts: &opt::Top) -> Result<Box<dyn traits::Emi
 
     let top_items: Vec<_> = top_items.into_iter().map(|i| i.id()).collect();
 
-    let top = Top {
+    Ok(Top {
         items: top_items,
         opts: opts.clone(),
-    };
-
-    Ok(Box::new(top) as Box<_>)
+    })
 }

--- a/analyze/analyze.rs
+++ b/analyze/analyze.rs
@@ -7,5 +7,10 @@ mod analyses;
 mod formats;
 
 pub use analyses::{
-    diff::diff, dominators::dominators, garbage::garbage, monos::monos, paths::paths, top::top,
+    diff::diff,
+    dominators::dominators,
+    garbage::garbage,
+    monos::monos,
+    paths::paths,
+    top::{top, Top},
 };

--- a/analyze/tests/top.rs
+++ b/analyze/tests/top.rs
@@ -1,0 +1,64 @@
+mod top_tests {
+    use twiggy_analyze::top;
+    use twiggy_ir::ItemsBuilder;
+    use twiggy_ir::{Id, Item, Misc};
+    use twiggy_opt::Top as Options;
+    use twiggy_traits::Error;
+
+    #[test]
+    fn empty() -> Result<(), Error> {
+        let builder = ItemsBuilder::new(0);
+        let mut items = builder.finish();
+        let opts = Options::default();
+        let top_items = top(&mut items, &opts)?;
+        assert_eq!(top_items.items(), []);
+        Ok(())
+    }
+
+    #[test]
+    fn one_item() -> Result<(), Error> {
+        let mut builder = ItemsBuilder::new(0);
+        builder.add_item(Item::new(
+            Id::entry(0, 0),
+            "0_10".to_string(),
+            10,
+            Misc::new(),
+        ));
+        let mut items = builder.finish();
+        let opts = Options::default();
+        let top_items = top(&mut items, &opts)?;
+        assert_eq!(top_items.items(), [Id::entry(0, 0)]);
+        Ok(())
+    }
+
+    #[test]
+    fn sorts_items() -> Result<(), Error> {
+        let mut builder = ItemsBuilder::new(0);
+        builder.add_item(Item::new(
+            Id::entry(0, 0),
+            "size 10".to_string(),
+            10,
+            Misc::new(),
+        ));
+        builder.add_item(Item::new(
+            Id::entry(0, 1),
+            "size 20".to_string(),
+            20,
+            Misc::new(),
+        ));
+        builder.add_item(Item::new(
+            Id::entry(0, 2),
+            "size 1".to_string(),
+            1,
+            Misc::new(),
+        ));
+        let mut items = builder.finish();
+        let opts = Options::default();
+        let top_items = top(&mut items, &opts)?;
+        assert_eq!(
+            top_items.items(),
+            [Id::entry(0, 1), Id::entry(0, 0), Id::entry(0, 2),]
+        );
+        Ok(())
+    }
+}

--- a/analyze/tests/top.rs
+++ b/analyze/tests/top.rs
@@ -1,64 +1,66 @@
 mod top_tests {
-    use twiggy_analyze::top;
-    use twiggy_ir::ItemsBuilder;
-    use twiggy_ir::{Id, Item, Misc};
-    use twiggy_opt::Top as Options;
-    use twiggy_traits::Error;
+    // FIXME: Types are still up in flux
 
-    #[test]
-    fn empty() -> Result<(), Error> {
-        let builder = ItemsBuilder::new(0);
-        let mut items = builder.finish();
-        let opts = Options::default();
-        let top_items = top(&mut items, &opts)?;
-        assert_eq!(top_items.items(), []);
-        Ok(())
-    }
+    // use twiggy_analyze::top;
+    // use twiggy_ir::ItemsBuilder;
+    // use twiggy_ir::{Id, Item, Misc};
+    // use twiggy_opt::Top as Options;
+    // use twiggy_traits::Error;
 
-    #[test]
-    fn one_item() -> Result<(), Error> {
-        let mut builder = ItemsBuilder::new(0);
-        builder.add_item(Item::new(
-            Id::entry(0, 0),
-            "0_10".to_string(),
-            10,
-            Misc::new(),
-        ));
-        let mut items = builder.finish();
-        let opts = Options::default();
-        let top_items = top(&mut items, &opts)?;
-        assert_eq!(top_items.items(), [Id::entry(0, 0)]);
-        Ok(())
-    }
+    // #[test]
+    // fn empty() -> Result<(), Error> {
+    // let builder = ItemsBuilder::new(0);
+    // let mut items = builder.finish();
+    // let opts = Options::default();
+    // let top_items = top(&mut items, &opts)?;
+    // assert_eq!(top_items.items(), []);
+    // Ok(())
+    // }
 
-    #[test]
-    fn sorts_items() -> Result<(), Error> {
-        let mut builder = ItemsBuilder::new(0);
-        builder.add_item(Item::new(
-            Id::entry(0, 0),
-            "size 10".to_string(),
-            10,
-            Misc::new(),
-        ));
-        builder.add_item(Item::new(
-            Id::entry(0, 1),
-            "size 20".to_string(),
-            20,
-            Misc::new(),
-        ));
-        builder.add_item(Item::new(
-            Id::entry(0, 2),
-            "size 1".to_string(),
-            1,
-            Misc::new(),
-        ));
-        let mut items = builder.finish();
-        let opts = Options::default();
-        let top_items = top(&mut items, &opts)?;
-        assert_eq!(
-            top_items.items(),
-            [Id::entry(0, 1), Id::entry(0, 0), Id::entry(0, 2),]
-        );
-        Ok(())
-    }
+    // #[test]
+    // fn one_item() -> Result<(), Error> {
+    // let mut builder = ItemsBuilder::new(0);
+    // builder.add_item(Item::new(
+    // Id::entry(0, 0),
+    // "0_10".to_string(),
+    // 10,
+    // Misc::new(),
+    // ));
+    // let mut items = builder.finish();
+    // let opts = Options::default();
+    // let top_items = top(&mut items, &opts)?;
+    // assert_eq!(top_items.items(), [Id::entry(0, 0)]);
+    // Ok(())
+    // }
+
+    // #[test]
+    // fn sorts_items() -> Result<(), Error> {
+    // let mut builder = ItemsBuilder::new(0);
+    // builder.add_item(Item::new(
+    // Id::entry(0, 0),
+    // "size 10".to_string(),
+    // 10,
+    // Misc::new(),
+    // ));
+    // builder.add_item(Item::new(
+    // Id::entry(0, 1),
+    // "size 20".to_string(),
+    // 20,
+    // Misc::new(),
+    // ));
+    // builder.add_item(Item::new(
+    // Id::entry(0, 2),
+    // "size 1".to_string(),
+    // 1,
+    // Misc::new(),
+    // ));
+    // let mut items = builder.finish();
+    // let opts = Options::default();
+    // let top_items = top(&mut items, &opts)?;
+    // assert_eq!(
+    // top_items.items(),
+    // [Id::entry(0, 1), Id::entry(0, 0), Id::entry(0, 2),]
+    // );
+    // Ok(())
+    // }
 }

--- a/twiggy/twiggy.rs
+++ b/twiggy/twiggy.rs
@@ -27,15 +27,15 @@ fn main() {
 fn run(opts: &opt::Options) -> Result<(), traits::Error> {
     let mut items = parser::read_and_parse(opts.input(), opts.parse_mode())?;
 
-    let data = match opts {
-        opt::Options::Top(ref top) => analyze::top(&mut items, top)?,
-        opt::Options::Dominators(ref doms) => analyze::dominators(&mut items, doms)?,
-        opt::Options::Paths(ref paths) => analyze::paths(&mut items, paths)?,
-        opt::Options::Monos(ref monos) => analyze::monos(&mut items, monos)?,
-        opt::Options::Garbage(ref garbo) => analyze::garbage(&items, garbo)?,
-        opt::Options::Diff(ref diff) => {
+    let data: Box<dyn traits::Emit> = match opts {
+        opt::Options::Top(top) => Box::new(analyze::top(&mut items, top)?),
+        opt::Options::Dominators(doms) => Box::new(analyze::dominators(&mut items, doms)?),
+        opt::Options::Paths(paths) => Box::new(analyze::paths(&mut items, paths)?),
+        opt::Options::Monos(monos) => Box::new(analyze::monos(&mut items, monos)?),
+        opt::Options::Garbage(garbo) => Box::new(analyze::garbage(&items, garbo)?),
+        opt::Options::Diff(diff) => {
             let mut new_items = parser::read_and_parse(diff.new_input(), opts.parse_mode())?;
-            analyze::diff(&mut items, &mut new_items, diff)?
+            Box::new(analyze::diff(&mut items, &mut new_items, diff)?)
         }
     };
 


### PR DESCRIPTION
Fixes #269.

Currently, we use snapshot tests to test `twiggy`. These are useful integration tests that help make sure that everything works properly, from parsing all the way to emitting data in a given format. However, it would be nice if we had tests specific to the `twiggy-analyze` crate.

My reasoning behind this is that there are a number of opaque test fixtures, that have been compiled manually. Additionally, there are a number of integration tests that test things like limiting the number of rows for example, that could be better represented as unit tests on the relevant analysis. Updating snapshots, and reviewing the diffs to make sure that they are all correct, also becomes more time consuming because above the above points.

This (currently WIP) patch introduces unit tests to the `twiggy-analyze` crate.