### PR TITLE
fix gitignore rule for build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+target
 **/*.rs.bk
 Cargo.lock
 twiggy/tests/all/whatever-output.txt


### PR DESCRIPTION
As is, the `.gitignore` file does not currently ignore `target` directories that may be created if we specifically build one of the workspace members. This fixes that rule, so that build artifacts in subdirectories are also ignored.