### PR TITLE
Remove failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,21 +50,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "backtrace"
-version = "0.3.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object 0.28.4",
- "rustc-demangle",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,12 +83,6 @@ dependencies = [
  "serde_derive",
  "toml",
 ]
-
-[[package]]
-name = "cc"
-version = "1.0.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
@@ -191,28 +161,6 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
 
 [[package]]
 name = "fallible-iterator"
@@ -360,15 +308,6 @@ dependencies = [
  "scroll",
  "target-lexicon",
  "uuid",
-]
-
-[[package]]
-name = "object"
-version = "0.28.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -561,18 +500,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
-]
-
-[[package]]
 name = "target-lexicon"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +515,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,9 +547,9 @@ dependencies = [
 name = "twiggy"
 version = "0.7.0"
 dependencies = [
+ "anyhow",
  "colored",
  "diff",
- "failure",
  "structopt",
  "twiggy-analyze",
  "twiggy-ir",
@@ -615,6 +562,7 @@ dependencies = [
 name = "twiggy-analyze"
 version = "0.7.0"
 dependencies = [
+ "anyhow",
  "csv",
  "petgraph",
  "regex",
@@ -641,6 +589,7 @@ dependencies = [
 name = "twiggy-opt"
 version = "0.7.0"
 dependencies = [
+ "anyhow",
  "cfg-if",
  "regex",
  "structopt",
@@ -652,9 +601,10 @@ dependencies = [
 name = "twiggy-parser"
 version = "0.7.0"
 dependencies = [
+ "anyhow",
  "fallible-iterator",
  "gimli",
- "object 0.17.0",
+ "object",
  "twiggy-ir",
  "twiggy-traits",
  "typed-arena",
@@ -665,10 +615,11 @@ dependencies = [
 name = "twiggy-traits"
 version = "0.7.0"
 dependencies = [
+ "anyhow",
  "csv",
- "failure",
  "gimli",
  "regex",
+ "thiserror",
  "twiggy-ir",
  "wasmparser",
 ]
@@ -708,12 +659,6 @@ name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "uuid"

--- a/analyze/Cargo.toml
+++ b/analyze/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 path = "./analyze.rs"
 
 [dependencies]
+anyhow = "1.0"
 twiggy-ir = { version = "=0.7.0", path = "../ir" }
 twiggy-opt = { version = "=0.7.0", path = "../opt", default-features = false }
 twiggy-traits = { version = "=0.7.0", path = "../traits" }

--- a/analyze/analyses/dominators/emit.rs
+++ b/analyze/analyses/dominators/emit.rs
@@ -15,7 +15,7 @@ use crate::formats::table::{Align, Table};
 
 impl traits::Emit for DominatorTree {
     #[cfg(feature = "emit_text")]
-    fn emit_text(&self, items: &ir::Items, dest: &mut dyn io::Write) -> Result<(), traits::Error> {
+    fn emit_text(&self, items: &ir::Items, dest: &mut dyn io::Write) -> anyhow::Result<()> {
         let mut table = Table::with_header(vec![
             (Align::Right, "Retained Bytes".to_string()),
             (Align::Right, "Retained %".to_string()),
@@ -93,14 +93,14 @@ impl traits::Emit for DominatorTree {
     }
 
     #[cfg(feature = "emit_json")]
-    fn emit_json(&self, items: &ir::Items, dest: &mut dyn io::Write) -> Result<(), traits::Error> {
+    fn emit_json(&self, items: &ir::Items, dest: &mut dyn io::Write) -> anyhow::Result<()> {
         fn recursive_add_children(
             items: &ir::Items,
             opts: &opt::Dominators,
             dominator_tree: &BTreeMap<ir::Id, Vec<ir::Id>>,
             id: ir::Id,
             obj: &mut json::Object,
-        ) -> Result<(), traits::Error> {
+        ) -> anyhow::Result<()> {
             add_json_item(items, id, obj)?;
 
             if let Some(children) = dominator_tree.get(&id) {
@@ -145,14 +145,14 @@ impl traits::Emit for DominatorTree {
     }
 
     #[cfg(feature = "emit_csv")]
-    fn emit_csv(&self, items: &ir::Items, dest: &mut dyn io::Write) -> Result<(), traits::Error> {
+    fn emit_csv(&self, items: &ir::Items, dest: &mut dyn io::Write) -> anyhow::Result<()> {
         fn recursive_add_children(
             items: &ir::Items,
             opts: &opt::Dominators,
             dominator_tree: &BTreeMap<ir::Id, Vec<ir::Id>>,
             id: ir::Id,
             wtr: &mut csv::Writer<&mut dyn io::Write>,
-        ) -> Result<(), traits::Error> {
+        ) -> anyhow::Result<()> {
             add_csv_item(items, id, wtr)?;
             if let Some(children) = dominator_tree.get(&id) {
                 let mut children = children.to_vec();
@@ -214,11 +214,7 @@ fn add_text_item(items: &ir::Items, depth: u32, id: ir::Id, table: &mut Table) {
 }
 
 #[cfg(feature = "emit_json")]
-fn add_json_item(
-    items: &ir::Items,
-    id: ir::Id,
-    obj: &mut json::Object,
-) -> Result<(), traits::Error> {
+fn add_json_item(items: &ir::Items, id: ir::Id, obj: &mut json::Object) -> anyhow::Result<()> {
     let item = &items[id];
 
     obj.field("name", item.name())?;
@@ -253,7 +249,7 @@ fn add_csv_item(
     items: &ir::Items,
     id: ir::Id,
     wtr: &mut csv::Writer<&mut dyn io::Write>,
-) -> Result<(), traits::Error> {
+) -> anyhow::Result<()> {
     let item = &items[id];
     let (shallow_size, shallow_size_percent) = (
         item.size(),

--- a/analyze/analyses/dominators/mod.rs
+++ b/analyze/analyses/dominators/mod.rs
@@ -27,7 +27,7 @@ struct UnreachableItemsSummary {
 pub fn dominators(
     items: &mut ir::Items,
     opts: &opt::Dominators,
-) -> Result<Box<dyn traits::Emit>, traits::Error> {
+) -> anyhow::Result<Box<dyn traits::Emit>> {
     items.compute_dominator_tree();
     items.compute_dominators();
     items.compute_retained_sizes();

--- a/analyze/analyses/garbage.rs
+++ b/analyze/analyses/garbage.rs
@@ -18,7 +18,7 @@ struct Garbage {
 
 impl traits::Emit for Garbage {
     #[cfg(feature = "emit_text")]
-    fn emit_text(&self, items: &ir::Items, dest: &mut dyn io::Write) -> Result<(), traits::Error> {
+    fn emit_text(&self, items: &ir::Items, dest: &mut dyn io::Write) -> anyhow::Result<()> {
         let mut table = Table::with_header(vec![
             (Align::Right, "Bytes".to_string()),
             (Align::Right, "Size %".to_string()),
@@ -78,7 +78,7 @@ impl traits::Emit for Garbage {
     }
 
     #[cfg(feature = "emit_json")]
-    fn emit_json(&self, items: &ir::Items, dest: &mut dyn io::Write) -> Result<(), traits::Error> {
+    fn emit_json(&self, items: &ir::Items, dest: &mut dyn io::Write) -> anyhow::Result<()> {
         let mut arr = json::array(dest)?;
 
         for &id in self.items.iter().take(self.limit) {
@@ -137,16 +137,13 @@ impl traits::Emit for Garbage {
     }
 
     #[cfg(feature = "emit_csv")]
-    fn emit_csv(&self, _items: &ir::Items, _dest: &mut dyn io::Write) -> Result<(), traits::Error> {
+    fn emit_csv(&self, _items: &ir::Items, _dest: &mut dyn io::Write) -> anyhow::Result<()> {
         unimplemented!();
     }
 }
 
 /// Find items that are not transitively referenced by any exports or public functions.
-pub fn garbage(
-    items: &ir::Items,
-    opts: &opt::Garbage,
-) -> Result<Box<dyn traits::Emit>, traits::Error> {
+pub fn garbage(items: &ir::Items, opts: &opt::Garbage) -> anyhow::Result<Box<dyn traits::Emit>> {
     let mut unreachable_items = get_unreachable_items(&items).collect::<Vec<_>>();
     unreachable_items.sort_by(|a, b| b.size().cmp(&a.size()));
 

--- a/analyze/analyses/monos/emit.rs
+++ b/analyze/analyses/monos/emit.rs
@@ -14,7 +14,7 @@ use super::Monos;
 
 impl traits::Emit for Monos {
     #[cfg(feature = "emit_text")]
-    fn emit_text(&self, items: &ir::Items, dest: &mut dyn io::Write) -> Result<(), traits::Error> {
+    fn emit_text(&self, items: &ir::Items, dest: &mut dyn io::Write) -> anyhow::Result<()> {
         struct TableRow {
             bloat: Option<u32>,
             bloat_percent: Option<f64>,
@@ -88,14 +88,14 @@ impl traits::Emit for Monos {
     }
 
     #[cfg(feature = "emit_json")]
-    fn emit_json(&self, items: &ir::Items, dest: &mut dyn io::Write) -> Result<(), traits::Error> {
+    fn emit_json(&self, items: &ir::Items, dest: &mut dyn io::Write) -> anyhow::Result<()> {
         // Given an entry representing a generic function and its various
         // monomorphizations, add its information to the given JSON object.
         fn process_entry(
             entry: &MonosEntry,
             obj: &mut json::Object,
             total_size: f64,
-        ) -> Result<(), traits::Error> {
+        ) -> anyhow::Result<()> {
             let get_size_percent = |size: u32| (f64::from(size)) / total_size * 100.0;
             let MonosEntry {
                 name,
@@ -135,7 +135,7 @@ impl traits::Emit for Monos {
     }
 
     #[cfg(feature = "emit_csv")]
-    fn emit_csv(&self, items: &ir::Items, dest: &mut dyn io::Write) -> Result<(), traits::Error> {
+    fn emit_csv(&self, items: &ir::Items, dest: &mut dyn io::Write) -> anyhow::Result<()> {
         // Calculate the total size of the collection of items, and define a
         // helper closure to calculate a percent value for a given u32 size.
         let items_size = f64::from(items.size());

--- a/analyze/analyses/monos/mod.rs
+++ b/analyze/analyses/monos/mod.rs
@@ -24,7 +24,7 @@ type MonosMap<'a> = BTreeMap<&'a str, Vec<(String, u32)>>;
 fn collect_monomorphizations<'a>(
     items: &'a ir::Items,
     opts: &opt::Monos,
-) -> Result<MonosMap<'a>, traits::Error> {
+) -> anyhow::Result<MonosMap<'a>> {
     let args_given = !opts.functions().is_empty();
     let using_regexps = opts.using_regexps();
     let regexps = regex::RegexSet::new(opts.functions())?;
@@ -184,10 +184,7 @@ fn add_stats(mut monos: Vec<MonosEntry>, opts: &opt::Monos) -> Vec<MonosEntry> {
 }
 
 /// Find bloaty monomorphizations of generic functions.
-pub fn monos(
-    items: &mut ir::Items,
-    opts: &opt::Monos,
-) -> Result<Box<dyn traits::Emit>, traits::Error> {
+pub fn monos(items: &mut ir::Items, opts: &opt::Monos) -> anyhow::Result<Box<dyn traits::Emit>> {
     let monos_map = collect_monomorphizations(items, opts)?;
     let mut monos = process_monomorphizations(monos_map, opts);
     monos = add_stats(monos, opts);

--- a/analyze/analyses/paths/mod.rs
+++ b/analyze/analyses/paths/mod.rs
@@ -18,10 +18,7 @@ struct Paths {
 }
 
 /// Find all retaining paths for the given items.
-pub fn paths(
-    items: &mut ir::Items,
-    opts: &opt::Paths,
-) -> Result<Box<dyn traits::Emit>, traits::Error> {
+pub fn paths(items: &mut ir::Items, opts: &opt::Paths) -> anyhow::Result<Box<dyn traits::Emit>> {
     // The predecessor tree only needs to be computed if we are ascending
     // through the retaining paths.
     if !opts.descending() {
@@ -42,10 +39,7 @@ pub fn paths(
 
 /// This helper function is used to collect the `ir::Id` values for the top-most
 /// path entries for the `Paths` object, based on the given options.
-fn get_starting_positions(
-    items: &ir::Items,
-    opts: &opt::Paths,
-) -> Result<Vec<ir::Id>, traits::Error> {
+fn get_starting_positions(items: &ir::Items, opts: &opt::Paths) -> anyhow::Result<Vec<ir::Id>> {
     // Collect Id's if no arguments are given and we are ascending the retaining paths.
     let get_functions_default = || -> Vec<ir::Id> {
         let mut sorted_items = items
@@ -67,7 +61,7 @@ fn get_starting_positions(
     };
 
     // Collect Id's if arguments were given that should be used as regular expressions.
-    let get_regexp_matches = || -> Result<Vec<ir::Id>, traits::Error> {
+    let get_regexp_matches = || -> anyhow::Result<Vec<ir::Id>> {
         let regexps = regex::RegexSet::new(opts.functions())?;
         let matches = items
             .iter()

--- a/analyze/analyses/paths/paths_emit.rs
+++ b/analyze/analyses/paths/paths_emit.rs
@@ -10,7 +10,7 @@ use twiggy_traits as traits;
 
 impl traits::Emit for Paths {
     #[cfg(feature = "emit_text")]
-    fn emit_text(&self, items: &ir::Items, dest: &mut dyn io::Write) -> Result<(), traits::Error> {
+    fn emit_text(&self, items: &ir::Items, dest: &mut dyn io::Write) -> anyhow::Result<()> {
         use self::emit_text_helpers::{process_entry, TableRow};
 
         // Flat map each entry and its children into a sequence of table rows.
@@ -55,7 +55,7 @@ impl traits::Emit for Paths {
     }
 
     #[cfg(feature = "emit_json")]
-    fn emit_json(&self, items: &ir::Items, dest: &mut dyn io::Write) -> Result<(), traits::Error> {
+    fn emit_json(&self, items: &ir::Items, dest: &mut dyn io::Write) -> anyhow::Result<()> {
         use self::emit_json_helpers::process_entry;
 
         // Initialize a JSON array. For each path entry, add a object to the
@@ -77,7 +77,7 @@ impl traits::Emit for Paths {
     }
 
     #[cfg(feature = "emit_csv")]
-    fn emit_csv(&self, items: &ir::Items, dest: &mut dyn io::Write) -> Result<(), traits::Error> {
+    fn emit_csv(&self, items: &ir::Items, dest: &mut dyn io::Write) -> anyhow::Result<()> {
         use self::emit_csv_helpers::process_entry;
 
         // First, initialize a CSV writer. Then, flat map each entry and its

--- a/analyze/analyses/top.rs
+++ b/analyze/analyses/top.rs
@@ -1,10 +1,10 @@
 use std::io;
 
-use csv;
-use serde_derive::Serialize;
-
 use crate::formats::json;
 use crate::formats::table::{Align, Table};
+use anyhow::anyhow;
+use csv;
+use serde_derive::Serialize;
 use twiggy_ir as ir;
 use twiggy_opt as opt;
 use twiggy_traits as traits;
@@ -16,7 +16,7 @@ struct Top {
 
 impl traits::Emit for Top {
     #[cfg(feature = "emit_text")]
-    fn emit_text(&self, items: &ir::Items, dest: &mut dyn io::Write) -> Result<(), traits::Error> {
+    fn emit_text(&self, items: &ir::Items, dest: &mut dyn io::Write) -> anyhow::Result<()> {
         // A struct used to represent a row in the table that will be emitted.
         struct TableRow {
             size: u32,
@@ -134,7 +134,7 @@ impl traits::Emit for Top {
     }
 
     #[cfg(feature = "emit_json")]
-    fn emit_json(&self, items: &ir::Items, dest: &mut dyn io::Write) -> Result<(), traits::Error> {
+    fn emit_json(&self, items: &ir::Items, dest: &mut dyn io::Write) -> anyhow::Result<()> {
         let mut arr = json::array(dest)?;
 
         let max_items = self.opts.max_items() as usize;
@@ -163,7 +163,7 @@ impl traits::Emit for Top {
     }
 
     #[cfg(feature = "emit_csv")]
-    fn emit_csv(&self, items: &ir::Items, dest: &mut dyn io::Write) -> Result<(), traits::Error> {
+    fn emit_csv(&self, items: &ir::Items, dest: &mut dyn io::Write) -> anyhow::Result<()> {
         let mut wtr = csv::Writer::from_writer(dest);
 
         #[derive(Serialize, Debug)]
@@ -209,11 +209,9 @@ impl traits::Emit for Top {
 }
 
 /// Run the `top` analysis on the given IR items.
-pub fn top(items: &mut ir::Items, opts: &opt::Top) -> Result<Box<dyn traits::Emit>, traits::Error> {
+pub fn top(items: &mut ir::Items, opts: &opt::Top) -> anyhow::Result<Box<dyn traits::Emit>> {
     if opts.retaining_paths() {
-        return Err(traits::Error::with_msg(
-            "retaining paths are not yet implemented",
-        ));
+        return Err(anyhow!("retaining paths are not yet implemented",));
     }
 
     if opts.retained() {

--- a/opt/Cargo.toml
+++ b/opt/Cargo.toml
@@ -16,6 +16,7 @@ path = "opt.rs"
 regex = "1.4.2"
 
 [dependencies]
+anyhow = "1.0"
 structopt = { version = "0.3", optional = true }
 twiggy-traits = { version = "=0.7.0", path = "../traits" }
 wasm-bindgen = { version = "0.2.80", optional = true }

--- a/opt/opt.rs
+++ b/opt/opt.rs
@@ -218,9 +218,9 @@ cfg_if! {
         }
 
         impl FromStr for OutputDestination {
-            type Err = traits::Error;
+            type Err = anyhow::Error;
 
-            fn from_str(s: &str) -> Result<Self, traits::Error> {
+            fn from_str(s: &str) -> anyhow::Result<Self> {
                 if s == "-" {
                     Ok(OutputDestination::Stdout)
                 } else {
@@ -232,7 +232,7 @@ cfg_if! {
 
         impl OutputDestination {
             /// Open the output destination as an `io::Write`.
-            pub fn open(&self) -> Result<Box<dyn io::Write>, traits::Error> {
+            pub fn open(&self) -> anyhow::Result<Box<dyn io::Write>> {
                 Ok(match *self {
                     OutputDestination::Path(ref path) => {
                         Box::new(io::BufWriter::new(fs::File::create(path)?)) as Box<_>

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 path = "./parser.rs"
 
 [dependencies]
+anyhow = "1.0"
 fallible-iterator = { version = "0.2.0", optional = true }
 gimli = { version = "0.26.1", optional = true, default-features = false, features = ["std", "read"] }
 object = { version = "0.17.0", optional = true }

--- a/parser/object_parse/compilation_unit_parse/mod.rs
+++ b/parser/object_parse/compilation_unit_parse/mod.rs
@@ -1,15 +1,14 @@
+use super::die_parse;
+use anyhow::anyhow;
 use gimli;
 use twiggy_ir as ir;
-use twiggy_traits as traits;
-
-use super::die_parse;
 
 pub(super) fn parse_items<R: gimli::Reader>(
     items: &mut ir::ItemsBuilder,
     dwarf: &gimli::Dwarf<R>,
     unit: &gimli::Unit<R>,
     unit_id: usize,
-) -> Result<(), traits::Error> {
+) -> anyhow::Result<()> {
     // Initialize an entry ID counter.
     let mut entry_id = 0;
 
@@ -17,10 +16,9 @@ pub(super) fn parse_items<R: gimli::Reader>(
     let mut die_cursor = unit.entries();
 
     if die_cursor.next_dfs()?.is_none() {
-        let e = traits::Error::with_msg(
+        return Err(anyhow!(
             "Unexpected error while traversing debugging information entries.",
-        );
-        return Err(e);
+        ));
     }
 
     // Parse the contained debugging information entries in depth-first order.
@@ -44,7 +42,7 @@ pub(super) fn parse_edges<R: gimli::Reader>(
     items: &mut ir::ItemsBuilder,
     unit: &gimli::Unit<R>,
     unit_id: usize,
-) -> Result<(), traits::Error> {
+) -> anyhow::Result<()> {
     // Initialize an entry ID counter.
     let mut entry_id = 0;
 
@@ -52,10 +50,9 @@ pub(super) fn parse_edges<R: gimli::Reader>(
     let mut die_cursor = unit.entries();
 
     if die_cursor.next_dfs()?.is_none() {
-        let e = traits::Error::with_msg(
-            "Unexpected error while traversing debugging information entries.",
-        );
-        return Err(e);
+        return Err(anyhow!(
+            "Unexpected error while traversing debugging information entries."
+        ));
     }
 
     // Parse the contained debugging information entries in depth-first order.

--- a/parser/object_parse/die_parse/item_name.rs
+++ b/parser/object_parse/die_parse/item_name.rs
@@ -1,7 +1,5 @@
-use gimli;
-use twiggy_traits as traits;
-
 use super::FallilbleOption;
+use gimli;
 
 /// Calculate the item's name. If no name was assigned, a name will be
 /// decided elsewhere using the `ir::ItemKind` variant that was determined
@@ -34,7 +32,7 @@ where
             x @ Some(_) => x,
             None => die.attr_value(gimli::DW_AT_name)?,
         };
-    attr.map(|attr| -> Result<String, traits::Error> {
+    attr.map(|attr| -> anyhow::Result<String> {
         Ok(
             dwarf
                 .attr_string(unit, attr)?

--- a/parser/object_parse/die_parse/location_attrs.rs
+++ b/parser/object_parse/die_parse/location_attrs.rs
@@ -1,8 +1,7 @@
+use super::FallilbleOption;
+use anyhow::anyhow;
 use fallible_iterator::FallibleIterator;
 use gimli;
-use twiggy_traits as traits;
-
-use super::FallilbleOption;
 
 /// This struct holds the values for DWARF attributes related to an object's
 /// location in a binary. This is intended to help consolidate the error
@@ -23,9 +22,7 @@ impl<R: gimli::Reader> DieLocationAttributes<R> {
     /// debugging information entry (DIE). Reading these attributes may fail,
     /// so this will return a Result rather than a plain `Self`.
     /// TODO: Use the TryFrom trait once it is stable.
-    pub fn try_from(
-        die: &gimli::DebuggingInformationEntry<R, R::Offset>,
-    ) -> Result<Self, traits::Error> {
+    pub fn try_from(die: &gimli::DebuggingInformationEntry<R, R::Offset>) -> anyhow::Result<Self> {
         Ok(Self {
             dw_at_low_pc: die.attr_value(gimli::DW_AT_low_pc)?,
             dw_at_high_pc: die.attr_value(gimli::DW_AT_high_pc)?,
@@ -62,9 +59,7 @@ impl<R: gimli::Reader> DieLocationAttributes<R> {
             // address in DW_AT_low_pc. If so, return the offset as the contiguous size.
             (Some(_), Some(gimli::AttributeValue::Udata(offset))) => Ok(Some(*offset)),
             // Return an error if DW_AT_high_pc is not encoded as expected.
-            (Some(_), Some(_)) => Err(traits::Error::with_msg(
-                "Unexpected DW_AT_high_pc attribute value",
-            )),
+            (Some(_), Some(_)) => Err(anyhow!("Unexpected DW_AT_high_pc attribute value")),
             // If none of the above conditions were met, this is either a
             // noncontiguous entity, or the DIE does not represent a defintion.
             _ => Ok(None),
@@ -94,9 +89,7 @@ impl<R: gimli::Reader> DieLocationAttributes<R> {
     fn dw_at_low_pc(&self) -> FallilbleOption<u64> {
         match &self.dw_at_low_pc {
             Some(gimli::AttributeValue::Addr(address)) => Ok(Some(*address)),
-            Some(_) => Err(traits::Error::with_msg(
-                "Unexpected base address attribute value",
-            )),
+            Some(_) => Err(anyhow!("Unexpected base address attribute value",)),
             None => Ok(None),
         }
     }
@@ -108,7 +101,7 @@ impl<R: gimli::Reader> DieLocationAttributes<R> {
     ) -> FallilbleOption<gimli::RawRangeListsOffset<<R as gimli::Reader>::Offset>> {
         match &self.dw_at_ranges {
             Some(gimli::AttributeValue::RangeListsRef(offset)) => Ok(Some(*offset)),
-            Some(_) => Err(traits::Error::with_msg("Unexpected DW_AT_ranges value")),
+            Some(_) => Err(anyhow!("Unexpected DW_AT_ranges value")),
             None => Ok(None),
         }
     }

--- a/parser/object_parse/die_parse/mod.rs
+++ b/parser/object_parse/die_parse/mod.rs
@@ -1,7 +1,5 @@
 use gimli;
 use twiggy_ir as ir;
-use twiggy_traits as traits;
-
 mod item_name;
 mod location_attrs;
 
@@ -10,7 +8,7 @@ use self::location_attrs::DieLocationAttributes;
 
 /// This type alias is used to represent an option return value for
 /// a procedure that could return an Error.
-type FallilbleOption<T> = Result<Option<T>, traits::Error>;
+type FallilbleOption<T> = anyhow::Result<Option<T>>;
 
 pub(super) fn parse_items<R: gimli::Reader>(
     items: &mut ir::ItemsBuilder,
@@ -19,7 +17,7 @@ pub(super) fn parse_items<R: gimli::Reader>(
     unit_id: usize,
     entry: &gimli::DebuggingInformationEntry<R>,
     entry_id: usize,
-) -> Result<(), traits::Error> {
+) -> anyhow::Result<()> {
     let item: ir::Item = match entry.tag() {
         gimli::DW_TAG_subprogram => {
             if let Some(size) = DieLocationAttributes::try_from(entry)?.entity_size(dwarf, unit)? {
@@ -27,7 +25,7 @@ pub(super) fn parse_items<R: gimli::Reader>(
                 let name = item_name(entry, dwarf, unit)?
                     .unwrap_or_else(|| format!("Subroutine[{}][{}]", unit_id, entry_id));
                 let kind: ir::ItemKind = ir::Code::new(&name).into();
-                ir::Item::new(id, name, size as u32, kind)
+                ir::Item::new(id, &name, size as u32, kind)
             } else {
                 return Ok(());
             }
@@ -42,7 +40,7 @@ pub(super) fn parse_items<R: gimli::Reader>(
 pub(super) fn parse_edges<R: gimli::Reader>(
     _items: &mut ir::ItemsBuilder,
     _entry: &gimli::DebuggingInformationEntry<R>,
-) -> Result<(), traits::Error> {
+) -> anyhow::Result<()> {
     // TODO: Add edges representing the call graph.
     Ok(())
 }

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -13,7 +13,8 @@ edition = "2018"
 path = "./traits.rs"
 
 [dependencies]
-failure = "0.1.8"
+thiserror = "1.0"
+anyhow = "1.0"
 gimli = { version = "0.26.1", optional = true, default-features = false, features = ["std", "read"] }
 wasmparser = "0.73.0"
 twiggy-ir = { version = "=0.7.0", path = "../ir" }

--- a/twiggy/Cargo.toml
+++ b/twiggy/Cargo.toml
@@ -17,7 +17,7 @@ name = "twiggy"
 path = "./twiggy.rs"
 
 [dependencies]
-failure = "0.1.8"
+anyhow = "1.0"
 structopt = "0.3"
 twiggy-analyze = { version = "=0.7.0", path = "../analyze" }
 twiggy-ir = { version = "=0.7.0", path = "../ir" }

--- a/twiggy/twiggy.rs
+++ b/twiggy/twiggy.rs
@@ -4,27 +4,20 @@
 #![deny(missing_debug_implementations)]
 
 use std::process;
-
-use failure::Fail;
 use structopt::StructOpt;
-
 use twiggy_analyze as analyze;
 use twiggy_opt::{self as opt, CommonCliOptions};
 use twiggy_parser as parser;
-use twiggy_traits as traits;
 
 fn main() {
     let options = opt::Options::from_args();
     if let Err(e) = run(&options) {
         eprintln!("error: {}", e);
-        for c in <dyn Fail>::iter_causes(&e) {
-            eprintln!("  caused by: {}", c);
-        }
         process::exit(1);
     }
 }
 
-fn run(opts: &opt::Options) -> Result<(), traits::Error> {
+fn run(opts: &opt::Options) -> anyhow::Result<()> {
     let mut items = parser::read_and_parse(opts.input(), opts.parse_mode())?;
 
     let data = match opts {


### PR DESCRIPTION
All errors are now using anyhow. 
We can now attach context and other bits of useful information to the errors.
I first experimented with using this_error so we have our own twiggy errors, but the old error type didn't do much besides wrap a bunch of other errors from various libraries.
This is why i've decided to use anyhow, since this is a palce where we the priority isn't as much having stable error types. 
They are used to just give more information to the program's users about what went wrong and `anyhow` is great at doing that.