### PR TITLE
Minor doc improvements 

### DIFF
--- a/guide/src/concepts/dominators-and-retained-size.md
+++ b/guide/src/concepts/dominators-and-retained-size.md
@@ -29,8 +29,9 @@ dominator tree for our call graph from earlier, where `shred` is the root:
 
 [<img alt="Dominator Tree" src="./dominator-tree.svg"/>](./dominator-tree.svg)
 
-Using the dominator relationship, we can find the *retained size* of some
-function by taking its shallow size and adding the retained sizes of each
-function that it immediately dominates.
+Using the dominator relationship,
+[`twiggy` can](../usage/command-line-interface/dominators.md) help you find the
+*retained size* of some function by taking its shallow size and adding the
+retained sizes of each function that it immediately dominates.
 
 [dominators]: https://en.wikipedia.org/wiki/Dominator_(graph_theory)

--- a/guide/src/concepts/generic-functions-and-monomorphization.md
+++ b/guide/src/concepts/generic-functions-and-monomorphization.md
@@ -89,6 +89,7 @@ AlsoThing z;
 generic(z);
 ```
 
-`twiggy` can analyze a binary to find which generic functions are being
-monomorphized repeatedly, and calculate an estimation of how much code size
-could be saved by switching from monomorphization to dynamic dispatch.
+[`twiggy` can analyze](../usage/command-line-interface/monos.md) a binary to
+find which generic functions are being monomorphized repeatedly, and calculate
+an estimation of how much code size could be saved by switching from
+monomorphization to dynamic dispatch.

--- a/guide/src/concepts/generic-functions-and-monomorphization.md
+++ b/guide/src/concepts/generic-functions-and-monomorphization.md
@@ -43,7 +43,7 @@ Example of dynamic dispatch in Rust:
 ```rust
 fn generic_function(t: &MyTrait) { ... }
 // or
-fn generic_function(t: Box<MyTrait>) { ... }
+fn generic_function(t: Box<dyn MyTrait>) { ... }
 // etc...
 
 // No more code bloat!

--- a/guide/src/concepts/paths.md
+++ b/guide/src/concepts/paths.md
@@ -20,9 +20,9 @@ your binary? Maybe it is deep down in some library you depend on, but inside a
 submodule of that library that you aren't using, and you wouldn't expect it to
 be included in the final binary.
 
-In this scenario, `twiggy` can show you all the paths in the call graph that
-lead to the unexpected function. This lets you understand why the unwelcome
-function is present, and decide what you can do about it. Maybe if you
-refactored your code to avoid calling *Y*, then there wouldn't be any paths to
-the unwelcome function anymore, it would be dead code, and the linker would
-remove it.
+In this scenario, [`twiggy` can show](../usage/command-line-interface/paths.md)
+you all the paths in the call graph that lead to the unexpected function. This
+lets you understand why the unwelcome function is present, and decide what you
+can do about it. Maybe if you refactored your code to avoid calling *Y*, then
+there wouldn't be any paths tothe unwelcome function anymore, it would be dead
+code, and the linker would remove it.


### PR DESCRIPTION
Added missing `dyn` keyword.

Added links from concepts pages to usage pages.