### PR TITLE
Support data segment name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,9 +717,9 @@ checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "wasmparser"
-version = "0.78.2"
+version = "0.79.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
+checksum = "5b5894be15a559c85779254700e1d35f02f843b5a69152e5c82c626d9fd66c0e"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,9 +717,9 @@ checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "wasmparser"
-version = "0.77.0"
+version = "0.78.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35c86d22e720a07d954ebbed772d01180501afe7d03d464f413bb5f8914a8d6"
+checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,9 +717,9 @@ checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "wasmparser"
-version = "0.73.1"
+version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8526ab131cbc49495a483c98954913ae7b83551adacab5e294cf77992e70ee7"
+checksum = "4a4d63608421d9a22d4bce220f2841f3b609a5aaabd3ed3aeeb5fed2702c3c78"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,9 +717,9 @@ checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "wasmparser"
-version = "0.79.0"
+version = "0.80.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5894be15a559c85779254700e1d35f02f843b5a69152e5c82c626d9fd66c0e"
+checksum = "449167e2832691a1bff24cde28d2804e90e09586a448c8e76984792c44334a6b"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,9 +717,9 @@ checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "wasmparser"
-version = "0.74.0"
+version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a4d63608421d9a22d4bce220f2841f3b609a5aaabd3ed3aeeb5fed2702c3c78"
+checksum = "755a9a4afe3f6cccbbe6d7e965eef44cf260b001f93e547eba84255c1d0187d8"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,9 +717,9 @@ checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "wasmparser"
-version = "0.76.0"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755a9a4afe3f6cccbbe6d7e965eef44cf260b001f93e547eba84255c1d0187d8"
+checksum = "b35c86d22e720a07d954ebbed772d01180501afe7d03d464f413bb5f8914a8d6"
 
 [[package]]
 name = "winapi"

--- a/ir/ir.rs
+++ b/ir/ir.rs
@@ -25,7 +25,7 @@ pub struct ItemsBuilder {
 
     // Maps the offset some data begins at to its IR item's identifier, and the
     // byte length of the data.
-    data: BTreeMap<u32, (Id, u32)>,
+    data: BTreeMap<u64, (Id, u64)>,
 }
 
 impl ItemsBuilder {
@@ -82,12 +82,12 @@ impl ItemsBuilder {
     pub fn link_data(&mut self, offset: i64, len: usize, id: Id) {
         if offset >= 0 && offset <= i64::from(u32::MAX) && offset as usize + len < u32::MAX as usize
         {
-            self.data.insert(offset as u32, (id, len as u32));
+            self.data.insert(offset as u64, (id, len as u64));
         }
     }
 
     /// Locate the data section defining memory at the given offset.
-    pub fn get_data(&self, offset: u32) -> Option<Id> {
+    pub fn get_data(&self, offset: u64) -> Option<Id> {
         self.data
             .range(offset..)
             .next()

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0"
 fallible-iterator = { version = "0.2.0", optional = true }
 gimli = { version = "0.27.2", optional = true, default-features = false, features = ["std", "read"] }
 object = { version = "0.17.0", optional = true }
-wasmparser = "0.77.0"
+wasmparser = "0.78.0"
 typed-arena = { version = "2.0.2", optional = true }
 twiggy-ir = { version = "=0.7.0", path = "../ir" }
 twiggy-traits = { version = "=0.7.0", path = "../traits" }

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0"
 fallible-iterator = { version = "0.2.0", optional = true }
 gimli = { version = "0.27.2", optional = true, default-features = false, features = ["std", "read"] }
 object = { version = "0.17.0", optional = true }
-wasmparser = "0.76.0"
+wasmparser = "0.77.0"
 typed-arena = { version = "2.0.2", optional = true }
 twiggy-ir = { version = "=0.7.0", path = "../ir" }
 twiggy-traits = { version = "=0.7.0", path = "../traits" }

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0"
 fallible-iterator = { version = "0.2.0", optional = true }
 gimli = { version = "0.27.2", optional = true, default-features = false, features = ["std", "read"] }
 object = { version = "0.17.0", optional = true }
-wasmparser = "0.74.0"
+wasmparser = "0.76.0"
 typed-arena = { version = "2.0.2", optional = true }
 twiggy-ir = { version = "=0.7.0", path = "../ir" }
 twiggy-traits = { version = "=0.7.0", path = "../traits" }

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0"
 fallible-iterator = { version = "0.2.0", optional = true }
 gimli = { version = "0.27.2", optional = true, default-features = false, features = ["std", "read"] }
 object = { version = "0.17.0", optional = true }
-wasmparser = "0.78.0"
+wasmparser = "0.79.0"
 typed-arena = { version = "2.0.2", optional = true }
 twiggy-ir = { version = "=0.7.0", path = "../ir" }
 twiggy-traits = { version = "=0.7.0", path = "../traits" }

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0"
 fallible-iterator = { version = "0.2.0", optional = true }
 gimli = { version = "0.27.2", optional = true, default-features = false, features = ["std", "read"] }
 object = { version = "0.17.0", optional = true }
-wasmparser = "0.79.0"
+wasmparser = "0.80.0"
 typed-arena = { version = "2.0.2", optional = true }
 twiggy-ir = { version = "=0.7.0", path = "../ir" }
 twiggy-traits = { version = "=0.7.0", path = "../traits" }

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0"
 fallible-iterator = { version = "0.2.0", optional = true }
 gimli = { version = "0.27.2", optional = true, default-features = false, features = ["std", "read"] }
 object = { version = "0.17.0", optional = true }
-wasmparser = "0.73.0"
+wasmparser = "0.74.0"
 typed-arena = { version = "2.0.2", optional = true }
 twiggy-ir = { version = "=0.7.0", path = "../ir" }
 twiggy-traits = { version = "=0.7.0", path = "../traits" }

--- a/parser/wasm_parse/mod.rs
+++ b/parser/wasm_parse/mod.rs
@@ -643,6 +643,7 @@ impl<'a> Parse<'a> for wasmparser::NameSectionReader<'a> {
                 wasmparser::Name::Module(_) => "\"module name\" subsection",
                 wasmparser::Name::Function(_) => "\"function names\" subsection",
                 wasmparser::Name::Local(_) => "\"local names\" subsection",
+                wasmparser::Name::Unknown { .. } => "\"unknown name\" subsection",
             };
             let id = Id::entry(idx, i);
             items.add_root(ir::Item::new(id, name, size, ir::DebugInfo::new()));

--- a/parser/wasm_parse/mod.rs
+++ b/parser/wasm_parse/mod.rs
@@ -155,6 +155,7 @@ impl<'a> Parse<'a> for ModuleReader<'a> {
                     name,
                     data,
                     data_offset,
+                    ..
                 } => {
                     CustomSectionReader {
                         name,
@@ -335,6 +336,7 @@ impl<'a> Parse<'a> for ModuleReader<'a> {
                     name,
                     data,
                     data_offset,
+                    ..
                 } => {
                     CustomSectionReader {
                         name,
@@ -445,6 +447,7 @@ fn parse_names_section<'a>(
             name: "name",
             data,
             data_offset,
+            ..
         } = section
         {
             for subsection in wasmparser::NameSectionReader::new(data, *data_offset)? {

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -16,7 +16,7 @@ path = "./traits.rs"
 thiserror = "1.0"
 anyhow = "1.0"
 gimli = { version = "0.27.2", optional = true, default-features = false, features = ["std", "read"] }
-wasmparser = "0.74.0"
+wasmparser = "0.76.0"
 twiggy-ir = { version = "=0.7.0", path = "../ir" }
 csv = "1.2.0"
 regex = "1.4.2"

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -16,7 +16,7 @@ path = "./traits.rs"
 thiserror = "1.0"
 anyhow = "1.0"
 gimli = { version = "0.27.2", optional = true, default-features = false, features = ["std", "read"] }
-wasmparser = "0.79.0"
+wasmparser = "0.80.0"
 twiggy-ir = { version = "=0.7.0", path = "../ir" }
 csv = "1.2.0"
 regex = "1.4.2"

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -16,7 +16,7 @@ path = "./traits.rs"
 thiserror = "1.0"
 anyhow = "1.0"
 gimli = { version = "0.27.2", optional = true, default-features = false, features = ["std", "read"] }
-wasmparser = "0.78.0"
+wasmparser = "0.79.0"
 twiggy-ir = { version = "=0.7.0", path = "../ir" }
 csv = "1.2.0"
 regex = "1.4.2"

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -16,7 +16,7 @@ path = "./traits.rs"
 thiserror = "1.0"
 anyhow = "1.0"
 gimli = { version = "0.27.2", optional = true, default-features = false, features = ["std", "read"] }
-wasmparser = "0.73.0"
+wasmparser = "0.74.0"
 twiggy-ir = { version = "=0.7.0", path = "../ir" }
 csv = "1.2.0"
 regex = "1.4.2"

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -16,7 +16,7 @@ path = "./traits.rs"
 thiserror = "1.0"
 anyhow = "1.0"
 gimli = { version = "0.27.2", optional = true, default-features = false, features = ["std", "read"] }
-wasmparser = "0.76.0"
+wasmparser = "0.77.0"
 twiggy-ir = { version = "=0.7.0", path = "../ir" }
 csv = "1.2.0"
 regex = "1.4.2"

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -16,7 +16,7 @@ path = "./traits.rs"
 thiserror = "1.0"
 anyhow = "1.0"
 gimli = { version = "0.27.2", optional = true, default-features = false, features = ["std", "read"] }
-wasmparser = "0.77.0"
+wasmparser = "0.78.0"
 twiggy-ir = { version = "=0.7.0", path = "../ir" }
 csv = "1.2.0"
 regex = "1.4.2"


### PR DESCRIPTION
- Upgrade wasmparser from 0.73.0 to 0.80.0, which supports data subsection in the name section.
- Add support for data segment name