### PR TITLE
Update README.md: guide users to install the git version of twiggy

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Ensure that you have [the Rust toolchain installed](https://www.rust-lang.org/),
 then run:
 
 ```
-cargo install twiggy
+cargo install twiggy --git https://github.com/rustwasm/twiggy
 ```
 
 ## Learn More!


### PR DESCRIPTION
The latest release of twiggy on [crates.io](https://crates.io/crates/twiggy) is 0.7 from 2021.

I followed the instructions and installed twiggy from crates.io, tried to analyse a binary and got an error (should not parse the same key into multiple items).

Searched the github, found the issue and fix, and finally reinstalled twiggy, this time from github.

I think directing users to directly use the latest version will prevent some frustration, and maybe prevent some issues from being opened that are already fixed for a long time.